### PR TITLE
Update tracker and update events implementation

### DIFF
--- a/core/src/dsnp/api_types.rs
+++ b/core/src/dsnp/api_types.rs
@@ -1,9 +1,10 @@
 #![allow(dead_code)] // todo: remove after usage
-use crate::dsnp::{dsnp_types::DsnpId, encryption::EncryptionBehavior};
+use crate::dsnp::{dsnp_types::DsnpUserId, encryption::EncryptionBehavior};
 
 /// Raw page of Graph (or Key) data
-pub type Page = Vec<u8>;
+pub type PageBlob = Vec<u8>;
 
+/// KeyPair used for encryption and PRI calculations
 pub struct KeyPair<E: EncryptionBehavior> {
 	/// Public key
 	pub public_key: E::EncryptionInput,
@@ -12,18 +13,31 @@ pub struct KeyPair<E: EncryptionBehavior> {
 	pub private_key: E::DecryptionInput,
 }
 
+/// PublicKey type associated in `EncryptionBehavior`
 pub type PublicKey<E> = <E as EncryptionBehavior>::EncryptionInput;
 
+/// Privacy Type of the graph
+#[derive(Clone, Copy, PartialEq, Ord, Eq, PartialOrd, Debug, Hash)]
 pub enum PrivacyType {
+	/// publicly accessible graph
 	Public,
+
+	/// only accessible to owner of the graph and whoever it is shared with
 	Private,
 }
 
+/// Different connection type in social graph
+#[derive(Clone, Copy, PartialEq, Ord, Eq, PartialOrd, Debug, Hash)]
 pub enum ConnectionType {
+	/// Follow is a one-way connection type, which means it is only stored in follower side
 	Follow(PrivacyType),
+
+	/// Friendship is two-way connection type, which means it is stored in both sides and each
+	/// side can revoke the connection for both sides
 	Friendship(PrivacyType),
 }
 
+/// A trait defining configurable settings for sdk
 pub trait Config {
 	/// Graph page id
 	type PageId;
@@ -45,52 +59,108 @@ pub trait Config {
 	}
 }
 
+/// Encapsulates all the keys and page data that needs to be retrieved from chain
 pub struct Import<E: EncryptionBehavior> {
-	pub dsnp_user_id: DsnpId,
+	/// graph owner dsnp user id
+	pub dsnp_user_id: DsnpUserId,
+
+	/// graph keys associated with this graph which is used for encryption and PRI generation
 	pub keys: Vec<KeyPair<E>>,
-	pub pages: Vec<Page>,
+
+	/// Raw page data containing the social graph retrieved from chain
+	pub pages: Vec<PageBlob>,
 }
 
+/// A connection representation in graph sdk
 pub struct Connection {
-	pub dsnp_user_id: DsnpId,
+	/// dsnp user id of the user that this connection is associated with
+	pub dsnp_user_id: DsnpUserId,
+
+	/// connection type
 	pub connection_type: ConnectionType,
 }
 
+/// Encapsulates a dsnp user and their associated graph public keys
+/// It is primarily used for PRI calculations
 pub struct DsnpKeys<E: EncryptionBehavior> {
-	pub dsnp_user_id: DsnpId,
+	/// dsnp user id
+	pub dsnp_user_id: DsnpUserId,
+
+	/// public keys for the dsnp user
 	pub keys: Vec<PublicKey<E>>,
 }
 
+/// Difference kinds of actions that can be applied to the graph
 pub enum Action<E: EncryptionBehavior> {
+	/// an action that defines adding a connection in the social graph
 	Connect {
-		owner_dsnp_user_id: DsnpId,
+		/// owner of the social graph
+		owner_dsnp_user_id: DsnpUserId,
+
+		/// connection details
 		connection: Connection,
-		connection_key: Option<PublicKey<E>>, // included only if PRId calculation is required
+
+		/// public key associated with the user in the connection
+		/// included only if PRId calculation is required
+		connection_key: Option<PublicKey<E>>,
 	},
+
+	/// an action that defines removing an existing connection from social graph
 	Disconnect {
-		owner_dsnp_user_id: DsnpId,
+		/// owner of the social graph
+		owner_dsnp_user_id: DsnpUserId,
+
+		/// connection details
 		connection: Connection,
 	},
 }
 
+/// Output of graph sdk that defines the different updates that needs to be applied to chain
 pub enum Update<C: Config> {
+	/// A `Persist` type is used to upsert a page on the chain with latest changes
 	Persist {
-		owner_dsnp_user_id: DsnpId,
+		/// owner of the social graph
+		owner_dsnp_user_id: DsnpUserId,
+
+		/// schema id of this change, each graph has it's own schema so it depends on the graph type
+		/// which is modified
 		schema_id: C::SchemaId,
+
+		/// page id associated with changed page
 		page_id: C::PageId,
+
+		/// previous hash value is used to avoid updating a stale state
 		prev_hash: Vec<u8>,
+
+		/// social graph page data
 		payload: Vec<u8>,
 	},
+
+	/// A `Delete` type is used to remove a page from the chain
 	Delete {
-		owner_dsnp_user_id: DsnpId,
+		/// owner of the social graph
+		owner_dsnp_user_id: DsnpUserId,
+
+		/// schema id of this change, each graph has it's own schema so it depends on the graph type
+		/// which is modified
 		schema_id: C::SchemaId,
+
+		/// page id associated with changed page
 		page_id: C::PageId,
+
+		/// previous hash value is used to avoid updating a stale state
 		prev_hash: Vec<u8>,
 	},
 }
 
+/// Encapsulates details required to do a key rotation
 pub struct Rotation<E: EncryptionBehavior> {
-	owner_dsnp_user_id: DsnpId,
+	/// owner of the social graph
+	owner_dsnp_user_id: DsnpUserId,
+
+	/// previous key used for encryption and PRI calculations
 	prev_key: KeyPair<E>,
+
+	/// new key to use for encryption and PRI calculations
 	new_key: KeyPair<E>,
 }

--- a/core/src/dsnp/dsnp_types.rs
+++ b/core/src/dsnp/dsnp_types.rs
@@ -5,7 +5,7 @@ use serde::{
 use std::{cmp, error::Error, fmt};
 
 /// DSNP User Id
-pub type DsnpId = u64;
+pub type DsnpUserId = u64;
 
 /// Prid len in bytes
 const PRID_LEN_IN_BYTES: usize = 8;
@@ -48,7 +48,7 @@ pub struct DsnpUserPublicGraphChunk {
 pub struct DsnpGraphEdge {
 	/// DSNP User Id of object of relationship
 	#[serde(rename = "userId")]
-	pub user_id: u64,
+	pub user_id: DsnpUserId,
 
 	/// Unix epoch in seconds when this relationship was originally established rounded to the nearest 1000
 	pub since: u64,

--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -1,0 +1,1 @@
+pub mod updates;

--- a/core/src/graph/updates.rs
+++ b/core/src/graph/updates.rs
@@ -1,0 +1,211 @@
+#![allow(dead_code)] // todo: remove after usage
+use crate::{
+	dsnp::{api_types::ConnectionType, dsnp_types::DsnpUserId},
+	graph::updates::UpdateEvent::{Add, Remove},
+};
+use anyhow::{Error, Result};
+use std::{cmp::Ordering, collections::HashMap};
+
+#[derive(Clone, PartialEq, Ord, Eq, PartialOrd, Debug)]
+pub enum UpdateEvent {
+	Add { dsnp_user_id: DsnpUserId, connection_type: ConnectionType },
+	Remove { dsnp_user_id: DsnpUserId, connection_type: ConnectionType },
+}
+
+pub struct UpdateTracker {
+	updates: HashMap<ConnectionType, Vec<UpdateEvent>>,
+}
+
+impl UpdateTracker {
+	pub fn new() -> Self {
+		Self { updates: HashMap::new() }
+	}
+
+	pub fn register(&mut self, events: &[UpdateEvent]) -> Result<()> {
+		if events.iter().any(|e| self.contains(e)) {
+			return Err(Error::msg("event exists"))
+		}
+
+		for e in events {
+			match self.contains_complement(e) {
+				// removing the complement to cancel out a prior update
+				true => self.remove(&e.get_complement()),
+				// adding new update
+				false => self.add(e),
+			}
+		}
+
+		Ok(())
+	}
+
+	pub fn has_updates(&self) -> bool {
+		self.updates.iter().any(|(_, v)| !v.is_empty())
+	}
+
+	fn contains(&self, event: &UpdateEvent) -> bool {
+		match self.updates.get(event.get_connection_type()) {
+			Some(arr) => arr.contains(event),
+			None => false,
+		}
+	}
+
+	fn contains_complement(&self, event: &UpdateEvent) -> bool {
+		self.contains(&event.get_complement())
+	}
+
+	fn remove(&mut self, event: &UpdateEvent) {
+		if let Some(arr) = self.updates.get_mut(event.get_connection_type()) {
+			arr.retain(|e| e.ne(event));
+			if arr.is_empty() {
+				self.updates.remove(event.get_connection_type());
+			}
+		}
+	}
+
+	fn add(&mut self, event: &UpdateEvent) {
+		self.updates
+			.entry(*event.get_connection_type())
+			.or_default()
+			.push(event.clone());
+	}
+}
+
+impl UpdateEvent {
+	pub fn create_add(dsnp_user_id: DsnpUserId, connection_type: ConnectionType) -> Self {
+		UpdateEvent::Add { dsnp_user_id, connection_type }
+	}
+
+	pub fn create_remove(dsnp_user_id: DsnpUserId, connection_type: ConnectionType) -> Self {
+		UpdateEvent::Remove { dsnp_user_id, connection_type }
+	}
+
+	pub fn get_complement(&self) -> Self {
+		match self {
+			Add { dsnp_user_id, connection_type } =>
+				Remove { dsnp_user_id: *dsnp_user_id, connection_type: *connection_type },
+			Remove { dsnp_user_id, connection_type } =>
+				Add { dsnp_user_id: *dsnp_user_id, connection_type: *connection_type },
+		}
+	}
+
+	pub fn get_connection_type(&self) -> &ConnectionType {
+		match self {
+			Add { connection_type, .. } => connection_type,
+			Remove { connection_type, .. } => connection_type,
+		}
+	}
+
+	pub fn type_ordering(a: &UpdateEvent, b: &UpdateEvent) -> Ordering {
+		match (a, b) {
+			(Remove { .. }, Add { .. }) => Ordering::Less,
+			(Add { .. }, Remove { .. }) => Ordering::Greater,
+			_ => a.cmp(b),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::dsnp::api_types::PrivacyType;
+
+	#[test]
+	fn tracker_register_should_return_error_for_duplicate_events() {
+		// arrange
+		let mut tracker = UpdateTracker::new();
+		let event = UpdateEvent::create_add(1, ConnectionType::Follow(PrivacyType::Public));
+		tracker
+			.register(&[event.clone()])
+			.expect("Should have registered successfully!");
+
+		// act
+		let exists = tracker.contains(&event);
+		let res = tracker.register(&[event]);
+
+		// assert
+		assert!(exists);
+		assert!(res.is_err());
+	}
+
+	#[test]
+	fn tracker_register_should_remove_complement_events() {
+		// arrange
+		let mut tracker = UpdateTracker::new();
+		let events = vec![
+			UpdateEvent::create_add(1, ConnectionType::Follow(PrivacyType::Public)),
+			UpdateEvent::create_remove(2, ConnectionType::Follow(PrivacyType::Public)),
+		];
+		tracker.register(&events).expect("Should have registered successfully!");
+		let complements: Vec<UpdateEvent> =
+			events.as_slice().iter().map(|e| e.get_complement()).collect();
+
+		// act
+		let res = tracker.register(&complements);
+
+		// assert
+		assert!(res.is_ok());
+		assert_eq!(tracker.updates.len(), 0);
+		assert!(!tracker.has_updates());
+	}
+
+	#[test]
+	fn tracker_register_should_work_as_expected() {
+		// arrange
+		let mut tracker = UpdateTracker::new();
+		let events = vec![
+			UpdateEvent::create_add(1, ConnectionType::Follow(PrivacyType::Public)),
+			UpdateEvent::create_remove(2, ConnectionType::Follow(PrivacyType::Public)),
+			UpdateEvent::create_add(3, ConnectionType::Follow(PrivacyType::Private)),
+			UpdateEvent::create_remove(4, ConnectionType::Follow(PrivacyType::Private)),
+			UpdateEvent::create_add(5, ConnectionType::Friendship(PrivacyType::Public)),
+			UpdateEvent::create_remove(6, ConnectionType::Friendship(PrivacyType::Public)),
+			UpdateEvent::create_add(7, ConnectionType::Friendship(PrivacyType::Private)),
+			UpdateEvent::create_remove(8, ConnectionType::Friendship(PrivacyType::Private)),
+		];
+
+		// act
+		let res = tracker.register(&events);
+
+		// assert
+		assert!(res.is_ok());
+
+		let public_follow =
+			tracker.updates.get(&ConnectionType::Follow(PrivacyType::Public)).unwrap();
+		assert_eq!(public_follow.as_slice(), &events[..2]);
+
+		let private_follow =
+			tracker.updates.get(&ConnectionType::Follow(PrivacyType::Private)).unwrap();
+		assert_eq!(private_follow.as_slice(), &events[2..4]);
+
+		let public_friendship =
+			tracker.updates.get(&ConnectionType::Friendship(PrivacyType::Public)).unwrap();
+		assert_eq!(public_friendship.as_slice(), &events[4..6]);
+
+		let private_friendship =
+			tracker.updates.get(&ConnectionType::Friendship(PrivacyType::Private)).unwrap();
+		assert_eq!(private_friendship.as_slice(), &events[6..8]);
+
+		assert!(tracker.has_updates());
+	}
+
+	#[test]
+	fn tracker_event_sorter_should_prioritize_removes() {
+		// arrange
+		let mut events = vec![
+			UpdateEvent::create_add(1, ConnectionType::Follow(PrivacyType::Public)),
+			UpdateEvent::create_remove(2, ConnectionType::Follow(PrivacyType::Public)),
+		];
+
+		// act
+		events.sort_by(UpdateEvent::type_ordering);
+
+		// assert
+		assert_eq!(
+			events,
+			vec![
+				UpdateEvent::create_remove(2, ConnectionType::Follow(PrivacyType::Public)),
+				UpdateEvent::create_add(1, ConnectionType::Follow(PrivacyType::Public)),
+			]
+		)
+	}
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
 mod dsnp;
 mod frequency;
+mod graph;
 mod types;


### PR DESCRIPTION
# Goal
The goal of this PR is  to add Update Tracking capability in graph which allows efficient page updates to be generated for the  chain related graph data.
closes #6 

# Acceptence Criterea
- [x] Implements UpdateEvent
- [x] Implements UpdateTracker struct to keep track of these changes
- [x] handles update complements
- [x] Write tests

# Notes
added some more documentation to types