### PR TITLE
use schema ids in apis

### DIFF
--- a/config/resources/configs/frequency-rococo.json
+++ b/config/resources/configs/frequency-rococo.json
@@ -4,32 +4,53 @@
   "maxKeyPageSizeBytes": 65536,
   "schemaMap": [
     [
-      {
-        "connectionType": "follow",
-        "privacyType": "public"
-      },
-      11
+      11,
+      [
+        "1.0",
+        {
+          "connectionType": "follow",
+          "privacyType": "public"
+        }
+      ]
     ],
     [
-      {
-        "connectionType": "follow",
-        "privacyType": "private"
-      },
-      12
+      12,
+      [
+        "1.0",
+        {
+          "connectionType": "follow",
+          "privacyType": "private"
+        }
+      ]
     ],
     [
-      {
-        "connectionType": "friendship",
-        "privacyType": "public"
-      },
-      13
+      13,
+      [
+        "1.0",
+        {
+          "connectionType": "friendship",
+          "privacyType": "public"
+        }
+      ]
     ],
     [
+      14,
+      [
+        "1.0",
+        {
+          "connectionType": "friendship",
+          "privacyType": "private"
+        }
+      ]
+    ]
+  ],
+  "dsnpVersionMap": [
+    [
+      "1.0",
       {
-        "connectionType": "friendship",
-        "privacyType": "private"
-      },
-      14
+        "encryptionAlgo": "xSalsa20Poly1305",
+        "keyType": "x25519"
+      }
     ]
   ]
 }

--- a/config/resources/configs/frequency.json
+++ b/config/resources/configs/frequency.json
@@ -4,32 +4,53 @@
   "maxKeyPageSizeBytes": 65536,
   "schemaMap": [
     [
-      {
-        "connectionType": "follow",
-        "privacyType": "public"
-      },
-      1
+      1,
+      [
+        "1.0",
+        {
+          "connectionType": "follow",
+          "privacyType": "public"
+        }
+      ]
     ],
     [
-      {
-        "connectionType": "follow",
-        "privacyType": "private"
-      },
-      2
+      2,
+      [
+        "1.0",
+        {
+          "connectionType": "follow",
+          "privacyType": "private"
+        }
+      ]
     ],
     [
-      {
-        "connectionType": "friendship",
-        "privacyType": "public"
-      },
-      3
+      3,
+      [
+        "1.0",
+        {
+          "connectionType": "friendship",
+          "privacyType": "public"
+        }
+      ]
     ],
     [
+      4,
+      [
+        "1.0",
+        {
+          "connectionType": "friendship",
+          "privacyType": "private"
+        }
+      ]
+    ]
+  ],
+  "dsnpVersionMap": [
+    [
+      "1.0",
       {
-        "connectionType": "friendship",
-        "privacyType": "private"
-      },
-      4
+        "encryptionAlgo": "xSalsa20Poly1305",
+        "keyType": "x25519"
+      }
     ]
   ]
 }

--- a/config/src/builder.rs
+++ b/config/src/builder.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use crate::{DsnpVersionConfig, SchemaConfig, SchemaId};
+use crate::{Config, DsnpVersionConfig, SchemaConfig, SchemaId};
 use std::collections::HashMap;
 
 pub struct ConfigBuilder {
@@ -44,5 +44,15 @@ impl ConfigBuilder {
 	pub fn with_dsnp_version(mut self, dsnp_version: String, config: DsnpVersionConfig) -> Self {
 		self.dsnp_version_map.insert(dsnp_version, config);
 		self
+	}
+
+	pub fn build(self) -> Config {
+		Config {
+			schema_map: self.schema_map,
+			dsnp_version_map: self.dsnp_version_map,
+			max_page_id: self.max_page_id,
+			max_key_page_size_bytes: self.max_key_page_size_bytes,
+			max_graph_page_size_bytes: self.max_graph_page_size_bytes,
+		}
 	}
 }

--- a/config/src/builder.rs
+++ b/config/src/builder.rs
@@ -1,0 +1,48 @@
+#![allow(dead_code)]
+use crate::{DsnpVersionConfig, SchemaConfig, SchemaId};
+use std::collections::HashMap;
+
+pub struct ConfigBuilder {
+	max_graph_page_size_bytes: u32,
+	max_page_id: u32,
+	max_key_page_size_bytes: u32,
+	schema_map: HashMap<SchemaId, SchemaConfig>,
+	dsnp_version_map: HashMap<String, DsnpVersionConfig>,
+}
+
+impl ConfigBuilder {
+	pub fn new() -> Self {
+		Self {
+			dsnp_version_map: HashMap::new(),
+			schema_map: HashMap::new(),
+			max_graph_page_size_bytes: 1024,
+			max_page_id: 16,
+			max_key_page_size_bytes: 65536,
+		}
+	}
+
+	pub fn with_max_page_id(mut self, max_page_id: u32) -> Self {
+		self.max_page_id = max_page_id;
+		self
+	}
+
+	pub fn with_max_key_page_size_bytes(mut self, max_key_page_size_bytes: u32) -> Self {
+		self.max_key_page_size_bytes = max_key_page_size_bytes;
+		self
+	}
+
+	pub fn with_max_graph_page_size_bytes(mut self, max_graph_page_size_bytes: u32) -> Self {
+		self.max_graph_page_size_bytes = max_graph_page_size_bytes;
+		self
+	}
+
+	pub fn with_schema(mut self, schema_id: SchemaId, config: SchemaConfig) -> Self {
+		self.schema_map.insert(schema_id, config);
+		self
+	}
+
+	pub fn with_dsnp_version(mut self, dsnp_version: String, config: DsnpVersionConfig) -> Self {
+		self.dsnp_version_map.insert(dsnp_version, config);
+		self
+	}
+}

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,3 +1,5 @@
+mod builder;
+
 use apache_avro::Schema;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
@@ -61,10 +63,11 @@ impl ConnectionType {
 	}
 }
 
-#[derive(Clone, PartialEq, Ord, Eq, PartialOrd, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Environment {
 	Mainnet,
 	Rococo,
+	Dev(Config),
 }
 
 impl Environment {
@@ -72,6 +75,7 @@ impl Environment {
 		match self {
 			Environment::Mainnet => &MAINNET_CONFIG,
 			Environment::Rococo => &ROCOCO_CONFIG,
+			Environment::Dev(cfg) => &cfg,
 		}
 	}
 }
@@ -152,6 +156,21 @@ impl Config {
 			return Some(schema_config.connection_type)
 		}
 		None
+	}
+
+	pub fn get_schema_id_from_connection_type(
+		&self,
+		connection_type: ConnectionType,
+	) -> Option<SchemaId> {
+		self.schema_map
+			.iter()
+			.filter_map(|(k, v)| {
+				if v.connection_type == connection_type {
+					return Some(*k)
+				}
+				None
+			})
+			.next()
 	}
 }
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -4,12 +4,10 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::hash_map::HashMap;
 
-pub const MAINNET_CONFIG: &str = include_str!("../resources/configs/frequency.json");
-pub const ROCOCO_CONFIG: &str = include_str!("../resources/configs/frequency-rococo.json");
-
 pub type SchemaId = u16;
 
 lazy_static! {
+	// Schemas
 	pub static ref PUBLIC_KEY_SCHEMA: Schema =
 		Schema::parse_str(include_str!("../resources/schemas/public_key_schema.json")).unwrap();
 	pub static ref PUBLIC_GRAPH_CHUNK_SCHEMA: Schema =
@@ -20,6 +18,12 @@ lazy_static! {
 	pub static ref PRIVATE_GRAPH_CHUNK_SCHEMA: Schema =
 		Schema::parse_str(include_str!("../resources/schemas/user_private_graph_chunk.json"))
 			.unwrap();
+
+	// Configurations
+	pub static ref MAINNET_CONFIG: Config = include_str!("../resources/configs/frequency.json")
+		.try_into().unwrap();
+	pub static ref ROCOCO_CONFIG: Config = include_str!("../resources/configs/frequency-rococo.json")
+		.try_into().unwrap();
 }
 
 /// Privacy Type of the graph
@@ -57,6 +61,48 @@ impl ConnectionType {
 	}
 }
 
+#[derive(Clone, PartialEq, Ord, Eq, PartialOrd, Debug)]
+pub enum Environment {
+	Mainnet,
+	Rococo,
+}
+
+impl Environment {
+	pub fn get_config(&self) -> &Config {
+		match self {
+			Environment::Mainnet => &MAINNET_CONFIG,
+			Environment::Rococo => &ROCOCO_CONFIG,
+		}
+	}
+}
+
+#[derive(Clone, PartialEq, Ord, Eq, PartialOrd, Debug, Hash, Serialize, Deserialize)]
+pub struct SchemaConfig {
+	pub dsnp_version: String,
+	pub connection_type: ConnectionType,
+}
+
+#[derive(Clone, Copy, PartialEq, Ord, Eq, PartialOrd, Debug, Hash, Serialize, Deserialize)]
+pub enum EncryptionAlgorithm {
+	#[serde(rename = "xSalsa20Poly1305")]
+	XSalsa20Poly1305,
+}
+
+#[derive(Clone, Copy, PartialEq, Ord, Eq, PartialOrd, Debug, Hash, Serialize, Deserialize)]
+pub enum KeyType {
+	#[serde(rename = "x25519")]
+	X25519,
+}
+
+#[derive(Clone, PartialEq, Ord, Eq, PartialOrd, Debug, Hash, Serialize, Deserialize)]
+pub struct DsnpVersionConfig {
+	#[serde(rename = "encryptionAlgo")]
+	pub encryption_algo: EncryptionAlgorithm,
+
+	#[serde(rename = "keyType")]
+	pub key_type: KeyType,
+}
+
 #[serde_as]
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Config {
@@ -71,13 +117,41 @@ pub struct Config {
 
 	#[serde(rename = "schemaMap")]
 	#[serde_as(as = "Vec<(_, _)>")]
-	pub schema_map: HashMap<ConnectionType, SchemaId>,
+	pub schema_map: HashMap<SchemaId, SchemaConfig>,
+
+	#[serde(rename = "dsnpVersionMap")]
+	#[serde_as(as = "Vec<(_, _)>")]
+	pub dsnp_version_map: HashMap<String, DsnpVersionConfig>,
 }
 
 impl TryFrom<&str> for Config {
 	type Error = serde_json::Error;
 	fn try_from(s: &str) -> Result<Self, Self::Error> {
 		serde_json::from_str(s)
+	}
+}
+
+impl Config {
+	pub fn get_dsnp_config_from_schema_id(
+		&self,
+		schema_id: SchemaId,
+	) -> Option<(String, DsnpVersionConfig)> {
+		if let Some(schema_config) = self.schema_map.get(&schema_id) {
+			if let Some(dsnp_config) = self.dsnp_version_map.get(&schema_config.dsnp_version) {
+				return Some((schema_config.dsnp_version.clone(), dsnp_config.clone()))
+			}
+		}
+		None
+	}
+
+	pub fn get_connection_type_from_schema_id(
+		&self,
+		schema_id: SchemaId,
+	) -> Option<ConnectionType> {
+		if let Some(schema_config) = self.schema_map.get(&schema_id) {
+			return Some(schema_config.connection_type)
+		}
+		None
 	}
 }
 
@@ -104,20 +178,50 @@ mod test {
 
 	#[test]
 	fn config_import_success() -> Result<(), serde_json::Error> {
-		let parsed_config: Config = MAINNET_CONFIG.try_into()?;
-		let config = Config {
+		let expected_config = Config {
 			max_graph_page_size_bytes: 1024,
 			max_page_id: 16,
 			max_key_page_size_bytes: 65536,
+			dsnp_version_map: HashMap::from([(
+				"1.0".to_string(),
+				DsnpVersionConfig {
+					encryption_algo: EncryptionAlgorithm::XSalsa20Poly1305,
+					key_type: KeyType::X25519,
+				},
+			)]),
 			schema_map: HashMap::from([
-				(ConnectionType::Follow(PrivacyType::Public), 1),
-				(ConnectionType::Follow(PrivacyType::Private), 2),
-				(ConnectionType::Friendship(PrivacyType::Public), 3),
-				(ConnectionType::Friendship(PrivacyType::Private), 4),
+				(
+					1,
+					SchemaConfig {
+						dsnp_version: "1.0".to_string(),
+						connection_type: ConnectionType::Follow(PrivacyType::Public),
+					},
+				),
+				(
+					2,
+					SchemaConfig {
+						dsnp_version: "1.0".to_string(),
+						connection_type: ConnectionType::Follow(PrivacyType::Private),
+					},
+				),
+				(
+					3,
+					SchemaConfig {
+						dsnp_version: "1.0".to_string(),
+						connection_type: ConnectionType::Friendship(PrivacyType::Public),
+					},
+				),
+				(
+					4,
+					SchemaConfig {
+						dsnp_version: "1.0".to_string(),
+						connection_type: ConnectionType::Friendship(PrivacyType::Private),
+					},
+				),
 			]),
 		};
 
-		assert_eq!(parsed_config, config);
+		assert_eq!(MAINNET_CONFIG.clone(), expected_config);
 		Ok(())
 	}
 
@@ -132,6 +236,13 @@ mod test {
 		let _ = PUBLIC_GRAPH_SCHEMA;
 		let _ = PUBLIC_KEY_SCHEMA;
 		let _ = PRIVATE_GRAPH_CHUNK_SCHEMA;
+		Ok(())
+	}
+
+	#[test]
+	fn lazy_static_configs_are_valid() -> Result<(), apache_avro::Error> {
+		let _ = MAINNET_CONFIG;
+		let _ = ROCOCO_CONFIG;
 		Ok(())
 	}
 }

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -1,9 +1,6 @@
 use crate::{
 	dsnp::{
-		api_types::{
-			Action, Connection, ConnectionType, DsnpKeys, ImportBundle, PrivacyType, PublicKey,
-			Update,
-		},
+		api_types::{Action, Connection, DsnpKeys, ImportBundle, PrivacyType, PublicKey, Update},
 		dsnp_types::{DsnpGraphEdge, DsnpUserId},
 		encryption::EncryptionBehavior,
 	},
@@ -16,6 +13,7 @@ use crate::{
 	util::time::time_in_ksecs,
 };
 use anyhow::{Error, Result};
+use dsnp_graph_config::{Environment, SchemaId};
 use std::{cell::RefCell, cmp::min, collections::HashMap, marker::PhantomData, rc::Rc};
 
 const MAX_GRAPH_USERS_DEFAULT: usize = 1000;
@@ -23,6 +21,7 @@ const MAX_GRAPH_USERS_DEFAULT: usize = 1000;
 #[derive(Debug)]
 pub struct GraphState<E: EncryptionBehavior, const MAX_USERS: usize = MAX_GRAPH_USERS_DEFAULT> {
 	phantom: PhantomData<E>,
+	environment: Environment,
 	public_key_manager: Rc<RefCell<PublicKeyManager>>,
 	user_map: HashMap<DsnpUserId, UserGraph>,
 }
@@ -61,24 +60,26 @@ pub trait GraphAPI<E: EncryptionBehavior> {
 	fn get_connections_for_user_graph(
 		&self,
 		user_id: &DsnpUserId,
-		connection_type: &ConnectionType,
+		schema_id: &SchemaId,
 		include_pending: bool,
 	) -> Result<Vec<DsnpGraphEdge>>;
 }
 
 impl<const MAX_USERS: usize, E: EncryptionBehavior> GraphState<E, MAX_USERS> {
-	pub fn new() -> Self {
+	pub fn new(environment: Environment) -> Self {
 		Self {
 			phantom: PhantomData,
+			environment,
 			user_map: HashMap::<DsnpUserId, UserGraph>::new(),
 			public_key_manager: Rc::new(RefCell::from(PublicKeyManager::new())),
 		}
 	}
 
-	pub fn with_capacity(capacity: usize) -> Self {
+	pub fn with_capacity(environment: Environment, capacity: usize) -> Self {
 		let size = min(capacity, MAX_USERS);
 		Self {
 			phantom: PhantomData,
+			environment,
 			user_map: HashMap::<DsnpUserId, UserGraph>::with_capacity(size),
 			public_key_manager: Rc::new(RefCell::from(PublicKeyManager::new())),
 		}
@@ -112,8 +113,10 @@ impl<E: EncryptionBehavior, const M: usize> GraphAPI<E> for GraphState<E, M> {
 			))
 		}
 
-		self.user_map
-			.insert(*user_id, UserGraph::new(user_id, self.public_key_manager.clone()));
+		self.user_map.insert(
+			*user_id,
+			UserGraph::new(user_id, &self.environment, self.public_key_manager.clone()),
+		);
 		match self.user_map.get_mut(user_id) {
 			Some(graph) => Ok(graph),
 			None => Err(Error::msg("Unexpected error retrieving user graph")),
@@ -130,8 +133,16 @@ impl<E: EncryptionBehavior, const M: usize> GraphAPI<E> for GraphState<E, M> {
 	/// but pending updates will be preserved.
 	fn import_user_data(
 		&mut self,
-		ImportBundle { connection_type, pages, dsnp_keys, dsnp_user_id, key_pairs }: ImportBundle,
+		ImportBundle { schema_id, pages, dsnp_keys, dsnp_user_id, key_pairs }: ImportBundle,
 	) -> Result<()> {
+		let config = self.environment.get_config();
+		// todo use
+		// let dsnp_config = config
+		// 	.get_dsnp_config_from_schema_id(schema_id)
+		// 	.ok_or(Error::msg("Invalid schema id for environment!"))?;
+		let connection_type = config
+			.get_connection_type_from_schema_id(schema_id)
+			.ok_or(Error::msg("Invalid schema id for environment!"))?;
 		self.public_key_manager.borrow_mut().import_dsnp_keys(dsnp_keys)?;
 
 		let user_graph = match self.user_map.get_mut(&dsnp_user_id) {
@@ -150,7 +161,7 @@ impl<E: EncryptionBehavior, const M: usize> GraphAPI<E> for GraphState<E, M> {
 			false => vec![],
 		};
 
-		let graph = user_graph.graph_mut(&connection_type);
+		let graph = user_graph.graph_mut(&schema_id);
 		graph.clear();
 
 		match (connection_type.privacy_type(), include_secret_keys) {
@@ -185,13 +196,13 @@ impl<E: EncryptionBehavior, const M: usize> GraphAPI<E> for GraphState<E, M> {
 		if let Some(owner_graph) = self.user_map.get_mut(&action.owner_dsnp_user_id()) {
 			let update_event = match action {
 				Action::Connect {
-					connection: Connection { ref dsnp_user_id, ref connection_type },
+					connection: Connection { ref dsnp_user_id, ref schema_id },
 					..
-				} => UpdateEvent::create_add(*dsnp_user_id, *connection_type),
+				} => UpdateEvent::create_add(*dsnp_user_id, *schema_id),
 				Action::Disconnect {
-					connection: Connection { ref dsnp_user_id, ref connection_type },
+					connection: Connection { ref dsnp_user_id, ref schema_id },
 					..
-				} => UpdateEvent::create_remove(*dsnp_user_id, *connection_type),
+				} => UpdateEvent::create_remove(*dsnp_user_id, *schema_id),
 			};
 
 			return owner_graph.update_tracker_mut().register_update(&update_event)
@@ -204,7 +215,7 @@ impl<E: EncryptionBehavior, const M: usize> GraphAPI<E> for GraphState<E, M> {
 	fn get_connections_for_user_graph(
 		&self,
 		user_id: &DsnpUserId,
-		connection_type: &ConnectionType,
+		schema_id: &SchemaId,
 		include_pending: bool,
 	) -> Result<Vec<DsnpGraphEdge>> {
 		let user_graph = match self.user_map.get(user_id) {
@@ -212,13 +223,13 @@ impl<E: EncryptionBehavior, const M: usize> GraphAPI<E> for GraphState<E, M> {
 			None => return Err(Error::msg("user not present in graph state")),
 		};
 
-		let graph = user_graph.graph(connection_type);
+		let graph = user_graph.graph(&schema_id);
 		let mut connections: Vec<DsnpGraphEdge> = iter_graph_connections!(graph).cloned().collect();
 
 		if include_pending {
 			user_graph
 				.update_tracker()
-				.get_updates_for_connection_type(*connection_type)
+				.get_updates_for_schema_id(*schema_id)
 				.unwrap_or(&Vec::<UpdateEvent>::new())
 				.iter()
 				.cloned()

--- a/core/src/dsnp/api_types.rs
+++ b/core/src/dsnp/api_types.rs
@@ -1,5 +1,6 @@
 use crate::dsnp::{dsnp_types::DsnpUserId, encryption::EncryptionBehavior};
 use dryoc::keypair::{PublicKey as StackPublicKey, StackKeyPair};
+use dsnp_graph_config::SchemaId;
 pub use dsnp_graph_config::{ConnectionType, PrivacyType};
 use std::{cmp::Ordering, fmt::Debug};
 
@@ -41,9 +42,6 @@ pub type PublicKey<E> = <E as EncryptionBehavior>::EncryptionInput;
 /// Graph page id
 pub type PageId = u16;
 
-/// Schema ID
-pub type SchemaId = u16;
-
 /// Page Hash type
 pub type PageHash = u32;
 
@@ -56,8 +54,8 @@ pub struct ImportBundle {
 	/// graph owner dsnp user id
 	pub dsnp_user_id: DsnpUserId,
 
-	/// Connection type of graph being imported
-	pub connection_type: ConnectionType,
+	/// Schema id of imported data
+	pub schema_id: SchemaId,
 
 	/// key pairs associated with this graph which is used for encryption and PRI generation
 	pub key_pairs: Vec<StackKeyPair>,
@@ -74,8 +72,8 @@ pub struct Connection {
 	/// dsnp user id of the user that this connection is associated with
 	pub dsnp_user_id: DsnpUserId,
 
-	/// connection type
-	pub connection_type: ConnectionType,
+	/// Schema id of imported data
+	pub schema_id: SchemaId,
 }
 
 /// Encapsulates a dsnp user and their associated graph public keys
@@ -134,8 +132,8 @@ pub enum Update {
 		/// owner of the social graph
 		owner_dsnp_user_id: DsnpUserId,
 
-		/// type of the connection
-		connection_type: ConnectionType,
+		/// Schema id of imported data
+		schema_id: SchemaId,
 
 		/// page id associated with changed page
 		page_id: PageId,
@@ -152,8 +150,8 @@ pub enum Update {
 		/// owner of the social graph
 		owner_dsnp_user_id: DsnpUserId,
 
-		/// type of the connection
-		connection_type: ConnectionType,
+		/// Schema id of removed data
+		schema_id: SchemaId,
 
 		/// page id associated with changed page
 		page_id: PageId,

--- a/core/src/dsnp/encryption.rs
+++ b/core/src/dsnp/encryption.rs
@@ -21,7 +21,7 @@ pub trait EncryptionBehavior {
 }
 
 /// XSalsa20Poly1305 encryption algorithm
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct SealBox;
 
 impl EncryptionBehavior for SealBox {

--- a/core/src/frequency/mod.rs
+++ b/core/src/frequency/mod.rs
@@ -4,20 +4,20 @@ use dsnp_graph_config::{Config, MAINNET_CONFIG, ROCOCO_CONFIG};
 
 #[allow(dead_code)] // todo: remove
 /// A utility to read/write data from and to Frequency chain specific implementation of DSNP
-pub struct Frequency {
-	config: Config,
+pub struct Frequency<'a> {
+	config: &'a Config,
 }
 
-impl Frequency {
-	pub fn init(config: Config) -> Self {
+impl<'a> Frequency<'a> {
+	pub fn init(config: &'a Config) -> Self {
 		Frequency { config }
 	}
 
 	pub fn with_mainnet() -> Result<Self, ()> {
-		Ok(Self::init(MAINNET_CONFIG.try_into().map_err(|_| ())?))
+		Ok(Self::init(&MAINNET_CONFIG))
 	}
 
 	pub fn with_rococo() -> Result<Self, ()> {
-		Ok(Self::init(ROCOCO_CONFIG.try_into().map_err(|_| ())?))
+		Ok(Self::init(&ROCOCO_CONFIG))
 	}
 }

--- a/core/src/frequency/reader_writer.rs
+++ b/core/src/frequency/reader_writer.rs
@@ -14,13 +14,13 @@ use crate::{
 use anyhow::Result;
 
 /// DsnpBase implementation for Frequency
-impl DsnpBase for Frequency {
+impl DsnpBase for Frequency<'_> {
 	/// using SealBox for encryption and decryption
 	type Encryption = SealBox;
 }
 
 /// implementing DsnpReader for Frequency
-impl DsnpReader for Frequency {
+impl DsnpReader for Frequency<'_> {
 	fn read_public_key(data: &[u8]) -> Result<DsnpPublicKey> {
 		SchemaHandler::read_public_key(data)
 	}
@@ -48,7 +48,7 @@ impl DsnpReader for Frequency {
 }
 
 /// implementing DsnpWriter for Frequency
-impl DsnpWriter for Frequency {
+impl DsnpWriter for Frequency<'_> {
 	fn write_public_key(key: &DsnpPublicKey) -> Result<Vec<u8>> {
 		SchemaHandler::write_public_key(key)
 	}

--- a/core/src/graph/updates.rs
+++ b/core/src/graph/updates.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)] // todo: remove after usage
 use crate::{
 	dsnp::{
-		api_types::{ConnectionType, DsnpKeys, PublicKey, Update},
+		api_types::{DsnpKeys, PublicKey, Update},
 		dsnp_types::DsnpUserId,
 		encryption::EncryptionBehavior,
 	},
@@ -11,17 +11,18 @@ use crate::{
 	},
 };
 use anyhow::{Error, Result};
+use dsnp_graph_config::SchemaId;
 use std::{cmp::Ordering, collections::HashMap};
 
 #[derive(Clone, PartialEq, Ord, Eq, PartialOrd, Debug)]
 pub enum UpdateEvent {
-	Add { dsnp_user_id: DsnpUserId, connection_type: ConnectionType },
-	Remove { dsnp_user_id: DsnpUserId, connection_type: ConnectionType },
+	Add { dsnp_user_id: DsnpUserId, schema_id: SchemaId },
+	Remove { dsnp_user_id: DsnpUserId, schema_id: SchemaId },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct UpdateTracker {
-	updates: HashMap<ConnectionType, Vec<UpdateEvent>>,
+	updates: HashMap<SchemaId, Vec<UpdateEvent>>,
 }
 
 impl UpdateTracker {
@@ -60,22 +61,16 @@ impl UpdateTracker {
 		self.updates.iter().any(|(_, v)| !v.is_empty())
 	}
 
-	pub fn get_updates_for_connection_type(
-		&self,
-		connection_type: ConnectionType,
-	) -> Option<&Vec<UpdateEvent>> {
-		self.updates.get(&connection_type)
+	pub fn get_updates_for_schema_id(&self, schema_id: SchemaId) -> Option<&Vec<UpdateEvent>> {
+		self.updates.get(&schema_id)
 	}
 
-	pub fn get_mut_updates_for_connection_type(
-		&mut self,
-		connection_type: ConnectionType,
-	) -> &Vec<UpdateEvent> {
-		self.updates.entry(connection_type).or_default()
+	pub fn get_mut_updates_for_schema_id(&mut self, schema_id: SchemaId) -> &Vec<UpdateEvent> {
+		self.updates.entry(schema_id).or_default()
 	}
 
 	pub fn contains(&self, event: &UpdateEvent) -> bool {
-		match self.updates.get(event.get_connection_type()) {
+		match self.updates.get(event.get_schema_id()) {
 			Some(arr) => arr.contains(event),
 			None => false,
 		}
@@ -86,19 +81,16 @@ impl UpdateTracker {
 	}
 
 	fn remove(&mut self, event: &UpdateEvent) {
-		if let Some(arr) = self.updates.get_mut(event.get_connection_type()) {
+		if let Some(arr) = self.updates.get_mut(event.get_schema_id()) {
 			arr.retain(|e| e.ne(event));
 			if arr.is_empty() {
-				self.updates.remove(event.get_connection_type());
+				self.updates.remove(event.get_schema_id());
 			}
 		}
 	}
 
 	fn add(&mut self, event: &UpdateEvent) {
-		self.updates
-			.entry(*event.get_connection_type())
-			.or_default()
-			.push(event.clone());
+		self.updates.entry(*event.get_schema_id()).or_default().push(event.clone());
 	}
 
 	/// Clear out all pending updates
@@ -108,27 +100,27 @@ impl UpdateTracker {
 }
 
 impl UpdateEvent {
-	pub fn create_add(dsnp_user_id: DsnpUserId, connection_type: ConnectionType) -> Self {
-		UpdateEvent::Add { dsnp_user_id, connection_type }
+	pub fn create_add(dsnp_user_id: DsnpUserId, schema_id: SchemaId) -> Self {
+		UpdateEvent::Add { dsnp_user_id, schema_id }
 	}
 
-	pub fn create_remove(dsnp_user_id: DsnpUserId, connection_type: ConnectionType) -> Self {
-		UpdateEvent::Remove { dsnp_user_id, connection_type }
+	pub fn create_remove(dsnp_user_id: DsnpUserId, schema_id: SchemaId) -> Self {
+		UpdateEvent::Remove { dsnp_user_id, schema_id }
 	}
 
 	pub fn get_complement(&self) -> Self {
 		match self {
-			Add { dsnp_user_id, connection_type } =>
-				Remove { dsnp_user_id: *dsnp_user_id, connection_type: *connection_type },
-			Remove { dsnp_user_id, connection_type } =>
-				Add { dsnp_user_id: *dsnp_user_id, connection_type: *connection_type },
+			Add { dsnp_user_id, schema_id } =>
+				Remove { dsnp_user_id: *dsnp_user_id, schema_id: *schema_id },
+			Remove { dsnp_user_id, schema_id } =>
+				Add { dsnp_user_id: *dsnp_user_id, schema_id: *schema_id },
 		}
 	}
 
-	pub fn get_connection_type(&self) -> &ConnectionType {
+	pub fn get_schema_id(&self) -> &SchemaId {
 		match self {
-			Add { connection_type, .. } => connection_type,
-			Remove { connection_type, .. } => connection_type,
+			Add { schema_id, .. } => schema_id,
+			Remove { schema_id, .. } => schema_id,
 		}
 	}
 
@@ -168,7 +160,8 @@ mod test {
 	fn tracker_register_should_return_error_for_duplicate_events() {
 		// arrange
 		let mut tracker = UpdateTracker::new();
-		let event = UpdateEvent::create_add(1, ConnectionType::Follow(PrivacyType::Public));
+		let schema_id = 4;
+		let event = UpdateEvent::create_add(1, schema_id);
 		tracker
 			.register_update(&event.clone())
 			.expect("Should have registered successfully!");
@@ -186,9 +179,10 @@ mod test {
 	fn tracker_register_should_remove_complement_events() {
 		// arrange
 		let mut tracker = UpdateTracker::new();
+		let schema_id = 4;
 		let events = vec![
-			UpdateEvent::create_add(1, ConnectionType::Follow(PrivacyType::Public)),
-			UpdateEvent::create_remove(2, ConnectionType::Follow(PrivacyType::Public)),
+			UpdateEvent::create_add(1, schema_id),
+			UpdateEvent::create_remove(2, schema_id),
 		];
 		tracker.register_updates(&events).expect("Should have registered successfully!");
 		let complements: Vec<UpdateEvent> =
@@ -207,15 +201,14 @@ mod test {
 	fn tracker_register_should_work_as_expected() {
 		// arrange
 		let mut tracker = UpdateTracker::new();
+		let schema_1 = 4;
+		let schema_2 = 5;
+
 		let events = vec![
-			UpdateEvent::create_add(1, ConnectionType::Follow(PrivacyType::Public)),
-			UpdateEvent::create_remove(2, ConnectionType::Follow(PrivacyType::Public)),
-			UpdateEvent::create_add(3, ConnectionType::Follow(PrivacyType::Private)),
-			UpdateEvent::create_remove(4, ConnectionType::Follow(PrivacyType::Private)),
-			UpdateEvent::create_add(5, ConnectionType::Friendship(PrivacyType::Public)),
-			UpdateEvent::create_remove(6, ConnectionType::Friendship(PrivacyType::Public)),
-			UpdateEvent::create_add(7, ConnectionType::Friendship(PrivacyType::Private)),
-			UpdateEvent::create_remove(8, ConnectionType::Friendship(PrivacyType::Private)),
+			UpdateEvent::create_add(1, schema_1),
+			UpdateEvent::create_remove(2, schema_1),
+			UpdateEvent::create_add(3, schema_2),
+			UpdateEvent::create_remove(4, schema_2),
 		];
 
 		// act
@@ -224,21 +217,13 @@ mod test {
 		// assert
 		assert!(res.is_ok());
 
-		let public_follow =
-			tracker.updates.get(&ConnectionType::Follow(PrivacyType::Public)).unwrap();
-		assert_eq!(public_follow.as_slice(), &events[..2]);
+		let schema_1_events =
+			tracker.updates.get(&schema_1).unwrap();
+		assert_eq!(schema_1_events.as_slice(), &events[..2]);
 
-		let private_follow =
-			tracker.updates.get(&ConnectionType::Follow(PrivacyType::Private)).unwrap();
+		let schema_2_events =
+			tracker.updates.get(&schema_2).unwrap();
 		assert_eq!(private_follow.as_slice(), &events[2..4]);
-
-		let public_friendship =
-			tracker.updates.get(&ConnectionType::Friendship(PrivacyType::Public)).unwrap();
-		assert_eq!(public_friendship.as_slice(), &events[4..6]);
-
-		let private_friendship =
-			tracker.updates.get(&ConnectionType::Friendship(PrivacyType::Private)).unwrap();
-		assert_eq!(private_friendship.as_slice(), &events[6..8]);
 
 		assert!(tracker.has_updates());
 	}
@@ -246,9 +231,10 @@ mod test {
 	#[test]
 	fn tracker_event_sorter_should_prioritize_removes() {
 		// arrange
+		let schema_id = 4;
 		let mut events = vec![
-			UpdateEvent::create_add(1, ConnectionType::Follow(PrivacyType::Public)),
-			UpdateEvent::create_remove(2, ConnectionType::Follow(PrivacyType::Public)),
+			UpdateEvent::create_add(1, schema_id),
+			UpdateEvent::create_remove(2, schema_id),
 		];
 
 		// act
@@ -258,8 +244,8 @@ mod test {
 		assert_eq!(
 			events,
 			vec![
-				UpdateEvent::create_remove(2, ConnectionType::Follow(PrivacyType::Public)),
-				UpdateEvent::create_add(1, ConnectionType::Follow(PrivacyType::Public)),
+				UpdateEvent::create_remove(2, schema_id),
+				UpdateEvent::create_add(1, schema_id),
 			]
 		)
 	}

--- a/core/src/graph/updates.rs
+++ b/core/src/graph/updates.rs
@@ -154,7 +154,6 @@ impl<E: EncryptionBehavior> UpdateAPI<E> for UserGraph {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use crate::dsnp::api_types::PrivacyType;
 
 	#[test]
 	fn tracker_register_should_return_error_for_duplicate_events() {
@@ -180,10 +179,8 @@ mod test {
 		// arrange
 		let mut tracker = UpdateTracker::new();
 		let schema_id = 4;
-		let events = vec![
-			UpdateEvent::create_add(1, schema_id),
-			UpdateEvent::create_remove(2, schema_id),
-		];
+		let events =
+			vec![UpdateEvent::create_add(1, schema_id), UpdateEvent::create_remove(2, schema_id)];
 		tracker.register_updates(&events).expect("Should have registered successfully!");
 		let complements: Vec<UpdateEvent> =
 			events.as_slice().iter().map(|e| e.get_complement()).collect();
@@ -217,13 +214,11 @@ mod test {
 		// assert
 		assert!(res.is_ok());
 
-		let schema_1_events =
-			tracker.updates.get(&schema_1).unwrap();
+		let schema_1_events = tracker.updates.get(&schema_1).unwrap();
 		assert_eq!(schema_1_events.as_slice(), &events[..2]);
 
-		let schema_2_events =
-			tracker.updates.get(&schema_2).unwrap();
-		assert_eq!(private_follow.as_slice(), &events[2..4]);
+		let schema_2_events = tracker.updates.get(&schema_2).unwrap();
+		assert_eq!(schema_2_events.as_slice(), &events[2..4]);
 
 		assert!(tracker.has_updates());
 	}
@@ -232,10 +227,8 @@ mod test {
 	fn tracker_event_sorter_should_prioritize_removes() {
 		// arrange
 		let schema_id = 4;
-		let mut events = vec![
-			UpdateEvent::create_add(1, schema_id),
-			UpdateEvent::create_remove(2, schema_id),
-		];
+		let mut events =
+			vec![UpdateEvent::create_add(1, schema_id), UpdateEvent::create_remove(2, schema_id)];
 
 		// act
 		events.sort_by(UpdateEvent::type_ordering);
@@ -243,10 +236,7 @@ mod test {
 		// assert
 		assert_eq!(
 			events,
-			vec![
-				UpdateEvent::create_remove(2, schema_id),
-				UpdateEvent::create_add(1, schema_id),
-			]
+			vec![UpdateEvent::create_remove(2, schema_id), UpdateEvent::create_add(1, schema_id),]
 		)
 	}
 }

--- a/core/src/graph/user.rs
+++ b/core/src/graph/user.rs
@@ -34,8 +34,8 @@ impl UserGraph {
 		let graphs: GraphMap = environment
 			.get_config()
 			.schema_map
-			.iter()
-			.map(|(schema_id, _)| (*schema_id, Graph::new(environment.clone(), *schema_id)))
+			.keys()
+			.map(|schema_id| (*schema_id, Graph::new(environment.clone(), *schema_id)))
 			.collect();
 
 		Self {
@@ -127,27 +127,31 @@ mod test {
 	#[test]
 	fn new_creates_empty_graphs_for_all_connection_types() {
 		let user_id = 1;
-		let user_graph = UserGraph::new(&user_id, Rc::new(RefCell::from(PublicKeyManager::new())));
+		let env = Environment::Mainnet;
+		let user_graph =
+			UserGraph::new(&user_id, &env, Rc::new(RefCell::from(PublicKeyManager::new())));
 
 		assert_eq!(user_graph.user_id, user_id);
-		assert_eq!(
-			user_graph.graphs.contains_key(&ConnectionType::Follow(PrivacyType::Public)),
-			true
-		);
-		assert_eq!(
-			user_graph.graphs.contains_key(&ConnectionType::Follow(PrivacyType::Private)),
-			true
-		);
-		assert_eq!(
-			user_graph.graphs.contains_key(&ConnectionType::Friendship(PrivacyType::Public)),
-			true
-		);
-		assert_eq!(
-			user_graph
-				.graphs
-				.contains_key(&ConnectionType::Friendship(PrivacyType::Private)),
-			true
-		);
+		let follow_public_schema_id = env
+			.get_config()
+			.get_schema_id_from_connection_type(ConnectionType::Follow(PrivacyType::Public))
+			.expect("should exist");
+		assert_eq!(user_graph.graphs.contains_key(&follow_public_schema_id), true);
+		let follow_private_schema_id = env
+			.get_config()
+			.get_schema_id_from_connection_type(ConnectionType::Follow(PrivacyType::Private))
+			.expect("should exist");
+		assert_eq!(user_graph.graphs.contains_key(&follow_private_schema_id), true);
+		let friendship_public_schema_id = env
+			.get_config()
+			.get_schema_id_from_connection_type(ConnectionType::Friendship(PrivacyType::Public))
+			.expect("should exist");
+		assert_eq!(user_graph.graphs.contains_key(&friendship_public_schema_id), true);
+		let friendship_private_schema_id = env
+			.get_config()
+			.get_schema_id_from_connection_type(ConnectionType::Friendship(PrivacyType::Private))
+			.expect("should exist");
+		assert_eq!(user_graph.graphs.contains_key(&friendship_private_schema_id), true);
 
 		for graph in user_graph.graphs.values() {
 			let graph_len = iter_graph_connections!(graph).len();
@@ -157,43 +161,60 @@ mod test {
 
 	#[test]
 	fn graph_getter_gets_correct_graph_for_connection_type() {
-		let user_graph = UserGraph::new(&1, Rc::new(RefCell::from(PublicKeyManager::new())));
+		let env = Environment::Mainnet;
+		let user_graph = UserGraph::new(&1, &env, Rc::new(RefCell::from(PublicKeyManager::new())));
 		for p in [PrivacyType::Public, PrivacyType::Private] {
 			for c in [ConnectionType::Follow(p), ConnectionType::Friendship(p)] {
-				assert_eq!(user_graph.graph(&c).connection_type, c);
+				let schema_id =
+					env.get_config().get_schema_id_from_connection_type(c).expect("should exist");
+				assert_eq!(user_graph.graph(&schema_id).get_connection_type(), c);
 			}
 		}
 	}
 
 	#[test]
 	fn graph_mut_getter_gets_correct_graph_for_connection_type() {
-		let mut user_graph = UserGraph::new(&1, Rc::new(RefCell::from(PublicKeyManager::new())));
+		let env = Environment::Mainnet;
+		let mut user_graph =
+			UserGraph::new(&1, &env, Rc::new(RefCell::from(PublicKeyManager::new())));
 		for p in [PrivacyType::Public, PrivacyType::Private] {
 			for c in [ConnectionType::Follow(p), ConnectionType::Friendship(p)] {
-				assert_eq!(user_graph.graph_mut(&c).connection_type, c);
+				let schema_id =
+					env.get_config().get_schema_id_from_connection_type(c).expect("should exist");
+				assert_eq!(user_graph.graph_mut(&schema_id).get_connection_type(), c);
 			}
 		}
 	}
 
 	#[test]
 	fn graph_setter_overwrites_existing_graph() {
-		let mut user_graph = UserGraph::new(&1, Rc::new(RefCell::from(PublicKeyManager::new())));
+		let env = Environment::Mainnet;
+		let mut user_graph =
+			UserGraph::new(&1, &env, Rc::new(RefCell::from(PublicKeyManager::new())));
 		let connection_type = ConnectionType::Follow(PrivacyType::Public);
-		let mut new_graph = Graph::new(connection_type);
+		let schema_id = env
+			.get_config()
+			.get_schema_id_from_connection_type(connection_type)
+			.expect("should exist");
+		let mut new_graph = Graph::new(env, schema_id);
 		assert_eq!(new_graph.add_connection_to_page(&0, &2).is_ok(), true);
 
-		assert_ne!(*user_graph.graph(&connection_type), new_graph);
-		user_graph.set_graph(&connection_type, new_graph.clone());
-		assert_eq!(*user_graph.graph(&connection_type), new_graph);
+		assert_ne!(*user_graph.graph(&schema_id), new_graph);
+		user_graph.set_graph(&schema_id, new_graph.clone());
+		assert_eq!(*user_graph.graph(&schema_id), new_graph);
 	}
 
 	#[test]
 	fn clear_graph_clears_specific_graph_and_no_others() {
+		let env = Environment::Mainnet;
 		let graph = create_test_graph();
-		let mut user_graph = UserGraph::new(&1, Rc::new(RefCell::from(PublicKeyManager::new())));
+		let mut user_graph =
+			UserGraph::new(&1, &env, Rc::new(RefCell::from(PublicKeyManager::new())));
 		for p in [PrivacyType::Public, PrivacyType::Private] {
 			for c in [ConnectionType::Follow(p), ConnectionType::Friendship(p)] {
-				user_graph.set_graph(&c, graph.clone());
+				let schema_id =
+					env.get_config().get_schema_id_from_connection_type(c).expect("should exist");
+				user_graph.set_graph(&schema_id, graph.clone());
 			}
 		}
 
@@ -202,10 +223,14 @@ mod test {
 		}
 
 		let connection_type_to_clear = ConnectionType::Follow(PrivacyType::Public);
-		user_graph.clear_graph(&connection_type_to_clear);
+		let schema_id = env
+			.get_config()
+			.get_schema_id_from_connection_type(connection_type_to_clear)
+			.expect("should exist");
+		user_graph.clear_graph(&schema_id);
 
-		for (conn_type, g) in user_graph.graphs {
-			if conn_type == connection_type_to_clear {
+		for (schema_id_to_clear, g) in user_graph.graphs {
+			if schema_id_to_clear == schema_id {
 				assert_eq!(g.len(), 0);
 			} else {
 				assert_eq!(g.len(), 25);
@@ -215,11 +240,15 @@ mod test {
 
 	#[test]
 	fn clear_all_clears_all_graphs() {
+		let env = Environment::Mainnet;
 		let graph = create_test_graph();
-		let mut user_graph = UserGraph::new(&1, Rc::new(RefCell::from(PublicKeyManager::new())));
+		let mut user_graph =
+			UserGraph::new(&1, &env, Rc::new(RefCell::from(PublicKeyManager::new())));
 		for p in [PrivacyType::Public, PrivacyType::Private] {
 			for c in [ConnectionType::Follow(p), ConnectionType::Friendship(p)] {
-				user_graph.set_graph(&c, graph.clone());
+				let schema_id =
+					env.get_config().get_schema_id_from_connection_type(c).expect("should exist");
+				user_graph.set_graph(&schema_id, graph.clone());
 			}
 		}
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 pub mod api;
 pub mod dsnp;
 pub mod frequency;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 pub mod api;
 pub mod dsnp;
 pub mod frequency;


### PR DESCRIPTION
# Goal
The goal of this PR is address schema_id oriented graph and api structures

related to #35 

# Discussion
- Using schema ids instead of connection types
- add support for different environments

# Checklist
- [x] Fix Tests
