### PR TITLE
refactoring to support dsnp versions

### DIFF
--- a/config/resources/configs/frequency-rococo.json
+++ b/config/resources/configs/frequency-rococo.json
@@ -1,4 +1,5 @@
 {
+  "sdkMaxUsersGraphSize" : 1000,
   "maxGraphPageSizeBytes": 1024,
   "maxPageId": 16,
   "maxKeyPageSizeBytes": 65536,
@@ -44,13 +45,7 @@
       ]
     ]
   ],
-  "dsnpVersionMap": [
-    [
-      "1.0",
-      {
-        "encryptionAlgo": "xSalsa20Poly1305",
-        "keyType": "x25519"
-      }
-    ]
+  "dsnpVersions": [
+    "1.0"
   ]
 }

--- a/config/resources/configs/frequency.json
+++ b/config/resources/configs/frequency.json
@@ -1,4 +1,5 @@
 {
+  "sdkMaxUsersGraphSize" : 1000,
   "maxGraphPageSizeBytes": 1024,
   "maxPageId": 16,
   "maxKeyPageSizeBytes": 65536,
@@ -44,13 +45,7 @@
       ]
     ]
   ],
-  "dsnpVersionMap": [
-    [
-      "1.0",
-      {
-        "encryptionAlgo": "xSalsa20Poly1305",
-        "keyType": "x25519"
-      }
-    ]
+  "dsnpVersions": [
+      "1.0"
   ]
 }

--- a/config/src/builder.rs
+++ b/config/src/builder.rs
@@ -1,24 +1,31 @@
 #![allow(dead_code)]
-use crate::{Config, DsnpVersionConfig, SchemaConfig, SchemaId};
+use crate::{Config, DsnpVersion, SchemaConfig, SchemaId};
 use std::collections::HashMap;
 
 pub struct ConfigBuilder {
+	sdk_max_users_graph_size: u32,
 	max_graph_page_size_bytes: u32,
 	max_page_id: u32,
 	max_key_page_size_bytes: u32,
 	schema_map: HashMap<SchemaId, SchemaConfig>,
-	dsnp_version_map: HashMap<String, DsnpVersionConfig>,
+	dsnp_versions: Vec<DsnpVersion>,
 }
 
 impl ConfigBuilder {
 	pub fn new() -> Self {
 		Self {
-			dsnp_version_map: HashMap::new(),
 			schema_map: HashMap::new(),
 			max_graph_page_size_bytes: 1024,
 			max_page_id: 16,
 			max_key_page_size_bytes: 65536,
+			sdk_max_users_graph_size: 1000,
+			dsnp_versions: vec![],
 		}
+	}
+
+	pub fn with_sdk_max_users_graph_size(mut self, sdk_max_users_graph_size: u32) -> Self {
+		self.sdk_max_users_graph_size = sdk_max_users_graph_size;
+		self
 	}
 
 	pub fn with_max_page_id(mut self, max_page_id: u32) -> Self {
@@ -41,18 +48,14 @@ impl ConfigBuilder {
 		self
 	}
 
-	pub fn with_dsnp_version(mut self, dsnp_version: String, config: DsnpVersionConfig) -> Self {
-		self.dsnp_version_map.insert(dsnp_version, config);
-		self
-	}
-
 	pub fn build(self) -> Config {
 		Config {
+			sdk_max_users_graph_size: self.sdk_max_users_graph_size,
 			schema_map: self.schema_map,
-			dsnp_version_map: self.dsnp_version_map,
 			max_page_id: self.max_page_id,
 			max_key_page_size_bytes: self.max_key_page_size_bytes,
 			max_graph_page_size_bytes: self.max_graph_page_size_bytes,
+			dsnp_versions: self.dsnp_versions,
 		}
 	}
 }

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -208,6 +208,7 @@ impl GraphAPI for GraphState {
 		let related_dsnp_configs: HashSet<DsnpVersionConfig> =
 			schemas.iter().filter_map(|s| self.get_dsnp_config(*s)).collect();
 
+		// we are checking user existence on previous lines so we can unwrap safely here
 		let user_graph = self.user_map.get_mut(user_id).unwrap();
 		let mut result = vec![];
 		for dsnp_config in related_dsnp_configs.iter() {

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -1,8 +1,8 @@
 use crate::{
 	dsnp::{
-		api_types::{Action, Connection, DsnpKeys, ImportBundle, PrivacyType, PublicKey, Update},
+		api_types::{Action, Connection, DsnpKeys, ImportBundle, PrivacyType, Update},
+		dsnp_configs::DsnpVersionConfig,
 		dsnp_types::{DsnpGraphEdge, DsnpUserId},
-		encryption::EncryptionBehavior,
 	},
 	graph::{
 		key_manager::{PublicKeyManager, PublicKeyProvider, UserKeyProvider},
@@ -13,22 +13,25 @@ use crate::{
 	iter_graph_connections,
 	util::time::time_in_ksecs,
 };
-use anyhow::{Error, Result};
+use anyhow::{Error, Ok, Result};
 use dsnp_graph_config::{Environment, SchemaId};
-use std::{cell::RefCell, cmp::min, collections::HashMap, marker::PhantomData, rc::Rc};
-
-const MAX_GRAPH_USERS_DEFAULT: usize = 1000;
+use std::{
+	cell::RefCell,
+	cmp::min,
+	collections::{HashMap, HashSet},
+	ops::{Deref, DerefMut},
+	rc::Rc,
+};
 
 #[derive(Debug)]
-pub struct GraphState<E: EncryptionBehavior, const MAX_USERS: usize = MAX_GRAPH_USERS_DEFAULT> {
-	phantom: PhantomData<E>,
+pub struct GraphState {
 	environment: Environment,
 	public_key_manager: Rc<RefCell<PublicKeyManager>>,
 	pri_manager: Rc<RefCell<PriManager>>,
 	user_map: HashMap<DsnpUserId, UserGraph>,
 }
 
-pub trait GraphAPI<E: EncryptionBehavior> {
+pub trait GraphAPI {
 	/// Check if graph state contains a user
 	fn contains_user(&self, user_id: &DsnpUserId) -> bool;
 
@@ -46,13 +49,12 @@ pub trait GraphAPI<E: EncryptionBehavior> {
 	/// but pending updates will be preserved.
 	fn import_user_data(&mut self, payload: ImportBundle) -> Result<()>;
 
-	/// Calculate the necessary page updates for a user's graph, and
+	/// Calculate the necessary page updates for a user's graph using the active encryption key, and
 	/// return as a map of pages to be updated and/or removed
 	fn export_user_updates(
 		&mut self,
 		user_id: &DsnpUserId,
 		connection_keys: &Vec<DsnpKeys>,
-		encryption_key: (u64, &PublicKey<E>),
 	) -> Result<Vec<Update>>;
 
 	/// Apply an Action (Connect or Disconnect) to the list of pending actions for a user's graph
@@ -67,10 +69,9 @@ pub trait GraphAPI<E: EncryptionBehavior> {
 	) -> Result<Vec<DsnpGraphEdge>>;
 }
 
-impl<const MAX_USERS: usize, E: EncryptionBehavior> GraphState<E, MAX_USERS> {
+impl GraphState {
 	pub fn new(environment: Environment) -> Self {
 		Self {
-			phantom: PhantomData,
 			environment,
 			user_map: HashMap::<DsnpUserId, UserGraph>::new(),
 			public_key_manager: Rc::new(RefCell::from(PublicKeyManager::new())),
@@ -79,9 +80,8 @@ impl<const MAX_USERS: usize, E: EncryptionBehavior> GraphState<E, MAX_USERS> {
 	}
 
 	pub fn with_capacity(environment: Environment, capacity: usize) -> Self {
-		let size = min(capacity, MAX_USERS);
+		let size = min(capacity, environment.get_config().sdk_max_users_graph_size as usize);
 		Self {
-			phantom: PhantomData,
 			environment,
 			user_map: HashMap::<DsnpUserId, UserGraph>::with_capacity(size),
 			public_key_manager: Rc::new(RefCell::from(PublicKeyManager::new())),
@@ -90,11 +90,11 @@ impl<const MAX_USERS: usize, E: EncryptionBehavior> GraphState<E, MAX_USERS> {
 	}
 
 	pub fn capacity(&self) -> usize {
-		MAX_USERS
+		self.environment.get_config().sdk_max_users_graph_size as usize
 	}
 }
 
-impl<E: EncryptionBehavior, const M: usize> GraphAPI<E> for GraphState<E, M> {
+impl GraphAPI for GraphState {
 	/// Check if graph state contains a user
 	fn contains_user(&self, user_id: &DsnpUserId) -> bool {
 		self.user_map.contains_key(user_id)
@@ -107,7 +107,7 @@ impl<E: EncryptionBehavior, const M: usize> GraphAPI<E> for GraphState<E, M> {
 
 	/// Create a new, empty user graph
 	fn add_user_graph(&mut self, user_id: &DsnpUserId) -> Result<&mut UserGraph> {
-		if self.user_map.len() >= M {
+		if self.user_map.len() >= self.environment.get_config().sdk_max_users_graph_size as usize {
 			return Err(Error::msg("GraphState instance full"))
 		}
 
@@ -139,15 +139,18 @@ impl<E: EncryptionBehavior, const M: usize> GraphAPI<E> for GraphState<E, M> {
 		&mut self,
 		ImportBundle { schema_id, pages, dsnp_keys, dsnp_user_id, key_pairs }: ImportBundle,
 	) -> Result<()> {
+		let dsnp_config = self
+			.get_dsnp_config(schema_id)
+			.ok_or(Error::msg("Invalid schema id for environment!"))?;
 		let config = self.environment.get_config();
-		// todo use
-		// let dsnp_config = config
-		// 	.get_dsnp_config_from_schema_id(schema_id)
-		// 	.ok_or(Error::msg("Invalid schema id for environment!"))?;
 		let connection_type = config
 			.get_connection_type_from_schema_id(schema_id)
 			.ok_or(Error::msg("Invalid schema id for environment!"))?;
-		self.public_key_manager.borrow_mut().import_dsnp_keys(dsnp_keys)?;
+		self.public_key_manager
+			.deref()
+			.borrow_mut()
+			.deref_mut()
+			.import_dsnp_keys(dsnp_keys)?;
 
 		let user_graph = match self.user_map.get_mut(&dsnp_user_id) {
 			Some(graph) => graph,
@@ -171,11 +174,19 @@ impl<E: EncryptionBehavior, const M: usize> GraphAPI<E> for GraphState<E, M> {
 		match (connection_type.privacy_type(), include_secret_keys) {
 			(PrivacyType::Public, _) => graph.import_public(connection_type, pages),
 			(PrivacyType::Private, true) => {
-				graph.import_private(connection_type, &pages, resolved_keys)?;
-				self.pri_manager.borrow_mut().import_pri(dsnp_user_id, &pages)
+				graph.import_private(&dsnp_config, connection_type, &pages, resolved_keys)?;
+				self.pri_manager
+					.deref()
+					.borrow_mut()
+					.deref_mut()
+					.import_pri(dsnp_user_id, &pages)
 			},
-			(PrivacyType::Private, false) =>
-				self.pri_manager.borrow_mut().import_pri(dsnp_user_id, &pages),
+			(PrivacyType::Private, false) => self
+				.pri_manager
+				.deref()
+				.borrow_mut()
+				.deref_mut()
+				.import_pri(dsnp_user_id, &pages),
 		}?;
 
 		Ok(())
@@ -187,14 +198,23 @@ impl<E: EncryptionBehavior, const M: usize> GraphAPI<E> for GraphState<E, M> {
 		&mut self,
 		user_id: &DsnpUserId,
 		connection_keys: &Vec<DsnpKeys>,
-		encryption_key: (u64, &PublicKey<E>),
 	) -> Result<Vec<Update>> {
-		let user_graph = match self.user_map.get_mut(user_id) {
-			None => Err(Error::msg("User not found for graph export")),
-			Some(graph) => Ok(graph),
-		}?;
+		let schemas = self
+			.user_map
+			.get(user_id)
+			.ok_or(Error::msg("User not found for graph export"))?
+			.update_tracker()
+			.get_updated_schema_ids();
+		let related_dsnp_configs: HashSet<DsnpVersionConfig> =
+			schemas.iter().filter_map(|s| self.get_dsnp_config(*s)).collect();
 
-		user_graph.calculate_updates::<E>(connection_keys, encryption_key)
+		let user_graph = self.user_map.get_mut(user_id).unwrap();
+		let mut result = vec![];
+		for dsnp_config in related_dsnp_configs.iter() {
+			let updates = user_graph.calculate_updates(dsnp_config, connection_keys)?;
+			result.extend(updates);
+		}
+		Ok(result)
 	}
 
 	/// Apply an action (Connect, Disconnect) to a user's graph
@@ -256,61 +276,77 @@ impl<E: EncryptionBehavior, const M: usize> GraphAPI<E> for GraphState<E, M> {
 	}
 }
 
+impl GraphState {
+	fn get_dsnp_config(&self, schema_id: SchemaId) -> Option<DsnpVersionConfig> {
+		let config = self.environment.get_config();
+		if let Some(dsnp_version) = config.get_dsnp_version_from_schema_id(schema_id) {
+			return Some(DsnpVersionConfig::new(dsnp_version))
+		}
+		None
+	}
+}
+
 #[cfg(test)]
 mod test {
 	use crate::{
 		dsnp::{
 			api_types::{Connection, ResolvedKeyPair},
+			dsnp_configs::KeyPairType,
 			dsnp_types::DsnpPrid,
-			encryption::SealBox,
 		},
 		tests::helpers::ImportBundleBuilder,
 	};
 	use dryoc::keypair::StackKeyPair;
-	use dsnp_graph_config::ConnectionType;
+	use dsnp_graph_config::{builder::ConfigBuilder, ConnectionType};
 
 	use super::*;
-	const TEST_CAPACITY: usize = 10;
 
-	type TestGraphState<const M: usize = TEST_CAPACITY> = GraphState<SealBox, M>;
+	const TEST_CAPACITY: usize = 10;
 
 	#[test]
 	fn new_graph_state_with_capacity_sets_initial_hash_map_capacity() {
+		let env = Environment::Dev(
+			ConfigBuilder::new().with_sdk_max_users_graph_size(TEST_CAPACITY as u32).build(),
+		);
 		let capacity: usize = 5;
-		let new_state =
-			TestGraphState::<TEST_CAPACITY>::with_capacity(Environment::Mainnet, capacity);
+		let new_state = GraphState::with_capacity(env, capacity);
 		assert!(new_state.user_map.capacity() >= capacity);
 	}
 
 	#[test]
 	fn new_graph_state_with_capacity_caps_initial_hash_map_capacity() {
-		let new_state =
-			TestGraphState::<TEST_CAPACITY>::with_capacity(Environment::Mainnet, TEST_CAPACITY * 2);
+		let env = Environment::Dev(
+			ConfigBuilder::new().with_sdk_max_users_graph_size(TEST_CAPACITY as u32).build(),
+		);
+		let new_state = GraphState::with_capacity(env, TEST_CAPACITY * 2);
 		assert!(new_state.user_map.capacity() >= TEST_CAPACITY);
 	}
 
 	#[test]
 	fn graph_state_capacity() {
-		let state: TestGraphState = TestGraphState::new(Environment::Mainnet);
+		let env = Environment::Dev(
+			ConfigBuilder::new().with_sdk_max_users_graph_size(TEST_CAPACITY as u32).build(),
+		);
+		let state = GraphState::new(env);
 		assert_eq!(state.capacity(), TEST_CAPACITY);
 	}
 
 	#[test]
 	fn graph_contains_false() {
-		let state: TestGraphState = TestGraphState::new(Environment::Mainnet);
+		let state = GraphState::new(Environment::Mainnet);
 		assert!(!state.contains_user(&0));
 	}
 
 	#[test]
 	fn graph_contains_true() {
-		let mut state: TestGraphState = TestGraphState::new(Environment::Mainnet);
+		let mut state = GraphState::new(Environment::Mainnet);
 		let _ = state.add_user_graph(&0);
 		assert!(state.contains_user(&0));
 	}
 
 	#[test]
 	fn graph_len() {
-		let mut state: TestGraphState = TestGraphState::new(Environment::Mainnet);
+		let mut state = GraphState::new(Environment::Mainnet);
 		let _ = state.add_user_graph(&0);
 		assert_eq!(state.len(), 1);
 		let _ = state.add_user_graph(&1);
@@ -319,28 +355,28 @@ mod test {
 
 	#[test]
 	fn add_user_errors_if_graph_state_full() {
-		let mut state = TestGraphState::<1>::new(Environment::Mainnet);
+		let env = Environment::Dev(ConfigBuilder::new().with_sdk_max_users_graph_size(1).build());
+		let mut state = GraphState::new(env);
 		let _ = state.add_user_graph(&0);
 		assert!(state.add_user_graph(&1).is_err());
 	}
 
 	#[test]
 	fn add_duplicate_user_errors() {
-		let mut state: TestGraphState = TestGraphState::new(Environment::Mainnet);
+		let mut state = GraphState::new(Environment::Mainnet);
 		let _ = state.add_user_graph(&0);
 		assert!(state.add_user_graph(&0).is_err());
 	}
 	#[test]
 	fn add_user_success() -> Result<()> {
-		let mut state: TestGraphState = TestGraphState::new(Environment::Mainnet);
-
+		let mut state = GraphState::new(Environment::Mainnet);
 		state.add_user_graph(&0)?;
 		Ok(())
 	}
 
 	#[test]
 	fn remove_user_success() {
-		let mut state: TestGraphState = TestGraphState::new(Environment::Mainnet);
+		let mut state = GraphState::new(Environment::Mainnet);
 		let _ = state.add_user_graph(&0);
 		let _ = state.add_user_graph(&1);
 		state.remove_user_graph(&0);
@@ -351,7 +387,7 @@ mod test {
 
 	#[test]
 	fn remove_nonexistent_user_noop() {
-		let mut state: TestGraphState = TestGraphState::new(Environment::Mainnet);
+		let mut state = GraphState::new(Environment::Mainnet);
 		let _ = state.add_user_graph(&0);
 		let _ = state.add_user_graph(&1);
 		state.remove_user_graph(&99);
@@ -366,8 +402,8 @@ mod test {
 			.get_config()
 			.get_schema_id_from_connection_type(ConnectionType::Follow(PrivacyType::Public))
 			.expect("should exist");
-		let mut state: TestGraphState = TestGraphState::new(env.clone());
-		let keypair = StackKeyPair::gen();
+		let mut state = GraphState::new(env.clone());
+		let keypair = KeyPairType::Version1_0(StackKeyPair::gen());
 		let dsnp_user_id = 123;
 		let connections = vec![2, 3, 4, 5];
 		let input = ImportBundleBuilder::new(env, dsnp_user_id, schema_id)
@@ -402,12 +438,13 @@ mod test {
 			.get_config()
 			.get_schema_id_from_connection_type(ConnectionType::Follow(PrivacyType::Private))
 			.expect("should exist");
-		let mut state: TestGraphState = TestGraphState::new(env.clone());
-		let resolved_key = ResolvedKeyPair { key_pair: StackKeyPair::gen(), key_id: 1 };
+		let mut state = GraphState::new(env.clone());
+		let resolved_key =
+			ResolvedKeyPair { key_pair: KeyPairType::Version1_0(StackKeyPair::gen()), key_id: 1 };
 		let dsnp_user_id = 123;
 		let connections = vec![2, 3, 4, 5];
 		let input = ImportBundleBuilder::new(env, dsnp_user_id, schema_id)
-			.with_key_pairs(&vec![resolved_key.key_pair.clone()])
+			.with_key_pairs(&vec![resolved_key.clone().key_pair])
 			.with_encryption_key(resolved_key)
 			.with_page(1, &connections, &vec![])
 			.build();
@@ -440,7 +477,7 @@ mod test {
 			.get_config()
 			.get_schema_id_from_connection_type(ConnectionType::Friendship(PrivacyType::Private))
 			.expect("should exist");
-		let mut state: TestGraphState = TestGraphState::new(env.clone());
+		let mut state = GraphState::new(env.clone());
 		let dsnp_user_id = 123;
 		let connections = vec![2, 3, 4, 5];
 		let prids = vec![
@@ -483,7 +520,7 @@ mod test {
 			connection_key: None,
 		};
 
-		let mut state: TestGraphState = TestGraphState::new(env);
+		let mut state = GraphState::new(env);
 		let _ = state.add_user_graph(&0);
 		assert!(state.apply_action(&action).is_ok());
 		assert!(state.apply_action(&action).is_err());
@@ -496,7 +533,7 @@ mod test {
 			.get_config()
 			.get_schema_id_from_connection_type(ConnectionType::Follow(PrivacyType::Private))
 			.expect("should exist");
-		let mut state: TestGraphState = TestGraphState::new(env);
+		let mut state = GraphState::new(env);
 		assert!(state
 			.apply_action(&Action::Connect {
 				owner_dsnp_user_id: 0,
@@ -518,7 +555,7 @@ mod test {
 			owner_dsnp_user_id,
 			connection: Connection { dsnp_user_id: 1, schema_id },
 		};
-		let mut state: TestGraphState = TestGraphState::new(env);
+		let mut state = GraphState::new(env);
 		let _ = state.add_user_graph(&owner_dsnp_user_id);
 		assert!(state.apply_action(&action).is_ok());
 		assert!(state.apply_action(&action).is_err());
@@ -531,7 +568,7 @@ mod test {
 			.get_config()
 			.get_schema_id_from_connection_type(ConnectionType::Follow(PrivacyType::Private))
 			.expect("should exist");
-		let mut state: TestGraphState = TestGraphState::new(env);
+		let mut state = GraphState::new(env);
 		assert!(state
 			.apply_action(&Action::Disconnect {
 				owner_dsnp_user_id: 0,
@@ -548,8 +585,8 @@ mod test {
 			.get_config()
 			.get_schema_id_from_connection_type(ConnectionType::Follow(PrivacyType::Public))
 			.expect("should exist");
-		let mut state: TestGraphState = TestGraphState::new(env.clone());
-		let keypair = StackKeyPair::gen();
+		let mut state = GraphState::new(env.clone());
+		let keypair = KeyPairType::Version1_0(StackKeyPair::gen());
 		let dsnp_user_id = 123;
 		let connections = vec![2, 3, 4, 5];
 		let input = ImportBundleBuilder::new(env, dsnp_user_id, schema_id)

--- a/core/src/dsnp/api_types.rs
+++ b/core/src/dsnp/api_types.rs
@@ -1,4 +1,4 @@
-use crate::dsnp::{dsnp_types::DsnpUserId, encryption::EncryptionBehavior};
+use crate::dsnp::{dsnp_configs::KeyPairType, dsnp_types::DsnpUserId};
 use dryoc::keypair::{PublicKey as StackPublicKey, StackKeyPair};
 use dsnp_graph_config::SchemaId;
 pub use dsnp_graph_config::{ConnectionType, PrivacyType};
@@ -33,11 +33,8 @@ pub struct ResolvedKeyPair {
 	pub key_id: u64,
 
 	/// Public key
-	pub key_pair: StackKeyPair,
+	pub key_pair: KeyPairType,
 }
-
-/// PublicKey type associated in `EncryptionBehavior`
-pub type PublicKey<E> = <E as EncryptionBehavior>::EncryptionInput;
 
 /// Graph page id
 pub type PageId = u16;
@@ -45,10 +42,6 @@ pub type PageId = u16;
 /// Page Hash type
 pub type PageHash = u32;
 
-/// A trait defining configurable settings for sdk
-pub trait Config {
-	fn schema_for_connection_type(&self, connection_type: ConnectionType) -> SchemaId;
-}
 /// Encapsulates all the decryption keys and page data that need to be retrieved from chain
 pub struct ImportBundle {
 	/// graph owner dsnp user id
@@ -58,7 +51,7 @@ pub struct ImportBundle {
 	pub schema_id: SchemaId,
 
 	/// key pairs associated with this graph which is used for encryption and PRI generation
-	pub key_pairs: Vec<StackKeyPair>,
+	pub key_pairs: Vec<KeyPairType>,
 
 	/// published dsnp keys associated with this dsnp user
 	pub dsnp_keys: DsnpKeys,

--- a/core/src/dsnp/api_types.rs
+++ b/core/src/dsnp/api_types.rs
@@ -27,7 +27,7 @@ pub struct KeyData {
 }
 
 /// A resolved KeyPair used for encryption and PRI calculations
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ResolvedKeyPair {
 	/// Key identifier
 	pub key_id: u64,

--- a/core/src/dsnp/dsnp_configs.rs
+++ b/core/src/dsnp/dsnp_configs.rs
@@ -1,0 +1,109 @@
+use crate::dsnp::encryption::{EncryptionBehavior, SealBox};
+use dryoc::keypair::{PublicKey, StackKeyPair};
+use dsnp_graph_config::DsnpVersion;
+
+/// Dsnp versions hardcoded configuration
+#[derive(Clone, PartialEq, Debug, Eq, Hash)]
+pub enum DsnpVersionConfig {
+	/// Dsnp version 1.0
+	Version1_0 { algorithm: SealBox },
+}
+
+/// Public key types for dsnp versions
+#[derive(Clone, PartialEq, Debug)]
+pub enum PublicKeyType {
+	/// Dsnp version 1.0
+	Version1_0(PublicKey),
+}
+
+/// Keypair types for dsnp versions
+#[derive(Clone, PartialEq, Debug)]
+pub enum KeyPairType {
+	/// Dsnp version 1.0
+	Version1_0(StackKeyPair),
+}
+
+/// Secret key types for dsnp versions
+#[derive(Clone, PartialEq, Debug)]
+pub enum SecretKeyType {
+	/// Dsnp version 1.0
+	Version1_0(StackKeyPair),
+}
+
+impl DsnpVersionConfig {
+	pub fn new(version: DsnpVersion) -> Self {
+		match version {
+			DsnpVersion::Version1_0 => DsnpVersionConfig::Version1_0 { algorithm: SealBox },
+		}
+	}
+
+	pub fn get_algorithm(&self) -> Box<dyn EncryptionBehavior> {
+		match self {
+			DsnpVersionConfig::Version1_0 { algorithm } => Box::new(algorithm.clone()),
+		}
+	}
+}
+
+impl KeyPairType {
+	pub fn get_public_key_raw(&self) -> Vec<u8> {
+		match self {
+			KeyPairType::Version1_0(k) => k.public_key.to_vec(),
+		}
+	}
+}
+
+impl Into<PublicKeyType> for &KeyPairType {
+	fn into(self) -> PublicKeyType {
+		match self {
+			KeyPairType::Version1_0(k) => PublicKeyType::Version1_0(k.clone().public_key),
+		}
+	}
+}
+
+impl Into<SecretKeyType> for KeyPairType {
+	fn into(self) -> SecretKeyType {
+		match self {
+			KeyPairType::Version1_0(k) => SecretKeyType::Version1_0(k),
+		}
+	}
+}
+
+impl Into<PublicKeyType> for KeyPairType {
+	fn into(self) -> PublicKeyType {
+		match self {
+			KeyPairType::Version1_0(k) => PublicKeyType::Version1_0(k.public_key),
+		}
+	}
+}
+
+impl Into<DsnpVersionConfig> for &SecretKeyType {
+	fn into(self) -> DsnpVersionConfig {
+		match self {
+			SecretKeyType::Version1_0(_) => DsnpVersionConfig::new(DsnpVersion::Version1_0),
+		}
+	}
+}
+
+impl Into<DsnpVersionConfig> for &KeyPairType {
+	fn into(self) -> DsnpVersionConfig {
+		match self {
+			KeyPairType::Version1_0(_) => DsnpVersionConfig::new(DsnpVersion::Version1_0),
+		}
+	}
+}
+
+impl Into<DsnpVersionConfig> for &PublicKeyType {
+	fn into(self) -> DsnpVersionConfig {
+		match self {
+			PublicKeyType::Version1_0(_) => DsnpVersionConfig::new(DsnpVersion::Version1_0),
+		}
+	}
+}
+
+impl Into<Vec<u8>> for PublicKeyType {
+	fn into(self) -> Vec<u8> {
+		match self {
+			PublicKeyType::Version1_0(k) => k.to_vec(),
+		}
+	}
+}

--- a/core/src/dsnp/dsnp_configs.rs
+++ b/core/src/dsnp/dsnp_configs.rs
@@ -31,12 +31,14 @@ pub enum SecretKeyType {
 }
 
 impl DsnpVersionConfig {
+	/// creates a new `DsnpVersionConfig` based on the version enum
 	pub fn new(version: DsnpVersion) -> Self {
 		match version {
 			DsnpVersion::Version1_0 => DsnpVersionConfig::Version1_0 { algorithm: SealBox },
 		}
 	}
 
+	/// returns the encryption/description algorithm associated with dsnp version
 	pub fn get_algorithm(&self) -> Box<dyn EncryptionBehavior> {
 		match self {
 			DsnpVersionConfig::Version1_0 { algorithm } => Box::new(algorithm.clone()),
@@ -45,6 +47,7 @@ impl DsnpVersionConfig {
 }
 
 impl KeyPairType {
+	/// returns raw bytes of the public key for specified dsnp version
 	pub fn get_public_key_raw(&self) -> Vec<u8> {
 		match self {
 			KeyPairType::Version1_0(k) => k.public_key.to_vec(),
@@ -52,7 +55,8 @@ impl KeyPairType {
 	}
 }
 
-impl Into<PublicKeyType> for &KeyPairType {
+/// converts a reference of `KeyPairType` into a `PublicKeyType`
+impl Into<PublicKeyType> for &'_ KeyPairType {
 	fn into(self) -> PublicKeyType {
 		match self {
 			KeyPairType::Version1_0(k) => PublicKeyType::Version1_0(k.clone().public_key),
@@ -60,6 +64,7 @@ impl Into<PublicKeyType> for &KeyPairType {
 	}
 }
 
+/// converts a `KeyPairType` into a `SecretKeyType`
 impl Into<SecretKeyType> for KeyPairType {
 	fn into(self) -> SecretKeyType {
 		match self {
@@ -68,14 +73,7 @@ impl Into<SecretKeyType> for KeyPairType {
 	}
 }
 
-impl Into<PublicKeyType> for KeyPairType {
-	fn into(self) -> PublicKeyType {
-		match self {
-			KeyPairType::Version1_0(k) => PublicKeyType::Version1_0(k.public_key),
-		}
-	}
-}
-
+/// converts a `SecretKeyType` into a `DsnpVersionConfig`
 impl Into<DsnpVersionConfig> for &SecretKeyType {
 	fn into(self) -> DsnpVersionConfig {
 		match self {
@@ -84,6 +82,7 @@ impl Into<DsnpVersionConfig> for &SecretKeyType {
 	}
 }
 
+/// converts a `KeyPairType` into a `DsnpVersionConfig`
 impl Into<DsnpVersionConfig> for &KeyPairType {
 	fn into(self) -> DsnpVersionConfig {
 		match self {
@@ -92,6 +91,7 @@ impl Into<DsnpVersionConfig> for &KeyPairType {
 	}
 }
 
+/// converts a `PublicKeyType` into a `DsnpVersionConfig`
 impl Into<DsnpVersionConfig> for &PublicKeyType {
 	fn into(self) -> DsnpVersionConfig {
 		match self {
@@ -100,6 +100,7 @@ impl Into<DsnpVersionConfig> for &PublicKeyType {
 	}
 }
 
+/// converts a `PublicKeyType` into a `Vec<u8>`
 impl Into<Vec<u8>> for PublicKeyType {
 	fn into(self) -> Vec<u8> {
 		match self {

--- a/core/src/dsnp/encryption.rs
+++ b/core/src/dsnp/encryption.rs
@@ -1,56 +1,59 @@
+use crate::dsnp::dsnp_configs::{PublicKeyType, SecretKeyType};
 use anyhow::{Error, Result as AnyResult};
 use dryoc::{
 	classic::crypto_box::{crypto_box_seal, crypto_box_seal_open},
 	constants::CRYPTO_BOX_SEALBYTES,
-	dryocbox::{ByteArray, PublicKey},
-	keypair::StackKeyPair,
+	dryocbox::ByteArray,
 };
 
 /// Common trait for different encryption algorithms
 pub trait EncryptionBehavior {
-	/// encryption input type such as encryption key
-	type EncryptionInput;
-	/// decryption input type such as decryption key
-	type DecryptionInput;
-
 	/// encrypt the plain_data
-	fn encrypt(plain_data: &[u8], input: &Self::EncryptionInput) -> AnyResult<Vec<u8>>;
+	fn encrypt(&self, plain_data: &[u8], input: &PublicKeyType) -> AnyResult<Vec<u8>>;
 
 	/// decrypt the encrypted_data
-	fn decrypt(encrypted_data: &[u8], input: &Self::DecryptionInput) -> AnyResult<Vec<u8>>;
+	fn decrypt(&self, encrypted_data: &[u8], input: &SecretKeyType) -> AnyResult<Vec<u8>>;
 }
 
 /// XSalsa20Poly1305 encryption algorithm
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, PartialEq, Default, Hash)]
 pub struct SealBox;
 
 impl EncryptionBehavior for SealBox {
-	type EncryptionInput = PublicKey;
-	type DecryptionInput = StackKeyPair;
-
-	fn encrypt(plain_data: &[u8], input: &Self::EncryptionInput) -> AnyResult<Vec<u8>> {
-		let mut encrypted = vec![0u8; plain_data.len().saturating_add(CRYPTO_BOX_SEALBYTES)];
-		crypto_box_seal(&mut encrypted, plain_data, input.as_array())
-			.map_err(|e| Error::msg(format!("failed to encrypt {:?}", e)))?;
-		Ok(encrypted)
+	fn encrypt(&self, plain_data: &[u8], input: &PublicKeyType) -> AnyResult<Vec<u8>> {
+		match input {
+			PublicKeyType::Version1_0(key) => {
+				let mut encrypted =
+					vec![0u8; plain_data.len().saturating_add(CRYPTO_BOX_SEALBYTES)];
+				crypto_box_seal(&mut encrypted, plain_data, key.as_array())
+					.map_err(|e| Error::msg(format!("failed to encrypt {:?}", e)))?;
+				Ok(encrypted)
+			},
+		}
 	}
 
-	fn decrypt(encrypted_data: &[u8], input: &Self::DecryptionInput) -> AnyResult<Vec<u8>> {
-		let mut plain = vec![0u8; encrypted_data.len().saturating_sub(CRYPTO_BOX_SEALBYTES)];
-		crypto_box_seal_open(
-			plain.as_mut_slice(),
-			encrypted_data,
-			input.public_key.as_array(),
-			input.secret_key.as_array(),
-		)
-		.map_err(|e| Error::msg(format!("failed to decrypt {:?}", e)))?;
-		Ok(plain)
+	fn decrypt(&self, encrypted_data: &[u8], input: &SecretKeyType) -> AnyResult<Vec<u8>> {
+		match input {
+			SecretKeyType::Version1_0(key) => {
+				let mut plain =
+					vec![0u8; encrypted_data.len().saturating_sub(CRYPTO_BOX_SEALBYTES)];
+				crypto_box_seal_open(
+					plain.as_mut_slice(),
+					encrypted_data,
+					key.public_key.as_array(),
+					key.secret_key.as_array(),
+				)
+				.map_err(|e| Error::msg(format!("failed to decrypt {:?}", e)))?;
+				Ok(plain)
+			},
+		}
 	}
 }
 
 #[cfg(test)]
 mod test {
 	use super::*;
+	use crate::dsnp::dsnp_configs::KeyPairType;
 	use dryoc::keypair::StackKeyPair;
 
 	#[test]
@@ -60,9 +63,9 @@ mod test {
 			83, 98, 0, 10, 234, 88, 23, 54, 23, 23, 109, 198, 111, 70, 2, 89,
 		];
 
-		let key_pair = StackKeyPair::gen();
-		let encrypted = SealBox::encrypt(&plain_data, &key_pair.public_key).unwrap();
-		let decrypted = SealBox::decrypt(&encrypted, &key_pair).unwrap();
+		let key_pair = KeyPairType::Version1_0(StackKeyPair::gen());
+		let encrypted = SealBox.encrypt(&plain_data, &key_pair.clone().into()).unwrap();
+		let decrypted = SealBox.decrypt(&encrypted, &key_pair.into()).unwrap();
 
 		assert_eq!(decrypted, plain_data);
 	}
@@ -71,10 +74,10 @@ mod test {
 	fn sealbox_decrypting_corrupted_data_should_fail() {
 		let plain_data = vec![83, 98, 0, 10, 234, 88, 23, 54, 23, 23, 109, 198, 111, 70, 2, 89];
 
-		let key_pair = StackKeyPair::from_seed(&[0, 1, 2, 3, 4]);
-		let mut encrypted = SealBox::encrypt(&plain_data, &key_pair.public_key).unwrap();
+		let key_pair = KeyPairType::Version1_0(StackKeyPair::from_seed(&[0, 1, 2, 3, 4]));
+		let mut encrypted = SealBox.encrypt(&plain_data, &key_pair.clone().into()).unwrap();
 		encrypted[1] = encrypted[1].saturating_add(1); // corrupting data
-		let decrypted = SealBox::decrypt(&encrypted, &key_pair);
+		let decrypted = SealBox.decrypt(&encrypted, &key_pair.into());
 
 		assert!(decrypted.is_err());
 	}

--- a/core/src/dsnp/encryption.rs
+++ b/core/src/dsnp/encryption.rs
@@ -55,6 +55,7 @@ mod test {
 	use super::*;
 	use crate::dsnp::dsnp_configs::KeyPairType;
 	use dryoc::keypair::StackKeyPair;
+	use std::borrow::Borrow;
 
 	#[test]
 	fn sealbox_should_encrypt_and_decrypt_successfully() {
@@ -64,7 +65,7 @@ mod test {
 		];
 
 		let key_pair = KeyPairType::Version1_0(StackKeyPair::gen());
-		let encrypted = SealBox.encrypt(&plain_data, &key_pair.clone().into()).unwrap();
+		let encrypted = SealBox.encrypt(&plain_data, &key_pair.borrow().into()).unwrap();
 		let decrypted = SealBox.decrypt(&encrypted, &key_pair.into()).unwrap();
 
 		assert_eq!(decrypted, plain_data);
@@ -75,7 +76,7 @@ mod test {
 		let plain_data = vec![83, 98, 0, 10, 234, 88, 23, 54, 23, 23, 109, 198, 111, 70, 2, 89];
 
 		let key_pair = KeyPairType::Version1_0(StackKeyPair::from_seed(&[0, 1, 2, 3, 4]));
-		let mut encrypted = SealBox.encrypt(&plain_data, &key_pair.clone().into()).unwrap();
+		let mut encrypted = SealBox.encrypt(&plain_data, &key_pair.borrow().into()).unwrap();
 		encrypted[1] = encrypted[1].saturating_add(1); // corrupting data
 		let decrypted = SealBox.decrypt(&encrypted, &key_pair.into());
 

--- a/core/src/dsnp/mod.rs
+++ b/core/src/dsnp/mod.rs
@@ -1,5 +1,6 @@
 pub mod api_types;
 pub mod compression;
+pub mod dsnp_configs;
 pub mod dsnp_types;
 pub mod encryption;
 mod pseudo_relationship_identifier;

--- a/core/src/dsnp/reader_writer.rs
+++ b/core/src/dsnp/reader_writer.rs
@@ -1,5 +1,6 @@
 use crate::{
 	dsnp::{
+		dsnp_configs::{PublicKeyType, SecretKeyType},
 		dsnp_types::{DsnpInnerGraph, DsnpPublicKey},
 		encryption::EncryptionBehavior,
 	},
@@ -21,7 +22,7 @@ pub trait DsnpReader: DsnpBase {
 	/// reading private graph from binary
 	fn read_private_graph(
 		data: &[u8],
-		decryption_input: &<Self::Encryption as EncryptionBehavior>::DecryptionInput,
+		decryption_input: &SecretKeyType,
 	) -> Result<PrivateGraphChunk>;
 }
 
@@ -34,6 +35,6 @@ pub trait DsnpWriter: DsnpBase {
 	/// write private graph to binary
 	fn write_private_graph(
 		graph: &PrivateGraphChunk,
-		encryption_input: &<Self::Encryption as EncryptionBehavior>::EncryptionInput,
+		encryption_input: &PublicKeyType,
 	) -> Result<Vec<u8>>;
 }

--- a/core/src/frequency/reader_writer.rs
+++ b/core/src/frequency/reader_writer.rs
@@ -94,6 +94,7 @@ mod test {
 	};
 	use dryoc::keypair::StackKeyPair;
 	use rand::Rng;
+	use std::borrow::Borrow;
 
 	#[test]
 	fn public_graph_read_and_write_using_valid_input_should_succeed() {
@@ -140,7 +141,7 @@ mod test {
 		};
 		let key_pair = KeyPairType::Version1_0(StackKeyPair::gen());
 
-		let serialized = Frequency::write_private_graph(&private_graph, &key_pair.clone().into())
+		let serialized = Frequency::write_private_graph(&private_graph, &key_pair.borrow().into())
 			.expect("serialization should work");
 		let deserialized = Frequency::read_private_graph(&serialized, &key_pair.into())
 			.expect("deserialization should work");
@@ -164,7 +165,7 @@ mod test {
 		let key_pair = KeyPairType::Version1_0(StackKeyPair::gen());
 
 		let mut serialized =
-			Frequency::write_private_graph(&private_graph, &key_pair.clone().into())
+			Frequency::write_private_graph(&private_graph, &key_pair.borrow().into())
 				.expect("serialization should work");
 		serialized.pop(); // corrupting the input
 		let deserialized = Frequency::read_private_graph(&serialized, &key_pair.into());
@@ -194,8 +195,9 @@ mod test {
 
 		let private_graph = PrivateGraphChunk { inner_graph, key_id: 200, prids };
 		let key_pair = KeyPairType::Version1_0(StackKeyPair::gen());
-		let private_serialized = Frequency::write_private_graph(&private_graph, &key_pair.into())
-			.expect("serialization should work");
+		let private_serialized =
+			Frequency::write_private_graph(&private_graph, &key_pair.borrow().into())
+				.expect("serialization should work");
 
 		assert_eq!((public_serialized.len() - 1) / page_size + 1, 2);
 		assert_eq!((private_serialized.len() - 1) / page_size + 1, 3);

--- a/core/src/graph/graph.rs
+++ b/core/src/graph/graph.rs
@@ -11,7 +11,7 @@ use super::page::GraphPage;
 pub type PageMap = HashMap<PageId, GraphPage>;
 
 /// Graph structure to hold pages of connections of a single type
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Graph {
 	environment: Environment,
 	schema_id: SchemaId,

--- a/core/src/graph/key_manager.rs
+++ b/core/src/graph/key_manager.rs
@@ -415,9 +415,12 @@ mod tests {
 
 		// assert
 		let key = user_key_manager.get_resolved_key(id1);
-		assert_eq!(key, Some((key1, key_pair)));
+		assert_eq!(key, Some((key1.clone(), key_pair.clone())));
 
 		let keys = user_key_manager.get_all_resolved_keys();
-		assert_eq!(keys.len(), 1)
+		assert_eq!(keys.len(), 1);
+
+		let resolved_active = user_key_manager.get_resolved_active_key(dsnp_user_id);
+		assert_eq!(resolved_active, Some((key1, key_pair)));
 	}
 }

--- a/core/src/graph/page.rs
+++ b/core/src/graph/page.rs
@@ -3,11 +3,11 @@ use crate::{
 	util::time::time_in_ksecs,
 };
 use anyhow::{Error, Result};
-use dsnp_graph_config::DsnpVersionConfig;
 
 use crate::dsnp::{
 	compression::{CompressionBehavior, DeflateCompression},
-	encryption::{EncryptionBehavior, SealBox},
+	dsnp_configs::DsnpVersionConfig,
+	encryption::EncryptionBehavior,
 	schema::SchemaHandler,
 };
 
@@ -49,7 +49,7 @@ impl TryFrom<&PageData> for GraphPage {
 impl TryFrom<(&PageData, &DsnpVersionConfig, &Vec<ResolvedKeyPair>)> for GraphPage {
 	type Error = Error;
 	fn try_from(
-		(PageData { content_hash, content, page_id, .. }, _dsnp_config, keys): (
+		(PageData { content_hash, content, page_id, .. }, dsnp_version_config, keys): (
 			&PageData,
 			&DsnpVersionConfig,
 			&Vec<ResolvedKeyPair>,
@@ -59,12 +59,13 @@ impl TryFrom<(&PageData, &DsnpVersionConfig, &Vec<ResolvedKeyPair>)> for GraphPa
 			DsnpUserPrivateGraphChunk::try_from(content.as_slice())?;
 		let mut decrypted_chunk: Option<Vec<u8>> = None;
 
+		let algorithm = dsnp_version_config.get_algorithm();
 		// First try the key that was indicated in the page
 		if let Some(indicated_key) = keys.iter().find(|k| k.key_id == key_id) {
-			// TODO: instead of SealBox should use dsnp_config to determine which algorithm to use
-			if let Ok(data) =
-				SealBox::decrypt(&encrypted_compressed_private_graph, &indicated_key.key_pair)
-			{
+			if let Ok(data) = algorithm.decrypt(
+				&encrypted_compressed_private_graph,
+				&indicated_key.key_pair.clone().into(),
+			) {
 				decrypted_chunk = Some(data);
 			}
 		}
@@ -73,7 +74,9 @@ impl TryFrom<(&PageData, &DsnpVersionConfig, &Vec<ResolvedKeyPair>)> for GraphPa
 		decrypted_chunk = match decrypted_chunk {
 			Some(_) => decrypted_chunk,
 			None => keys.iter().find_map(|k| {
-				SealBox::decrypt(&encrypted_compressed_private_graph, &k.key_pair).ok()
+				algorithm
+					.decrypt(&encrypted_compressed_private_graph, &k.key_pair.clone().into())
+					.ok()
 			}),
 		};
 
@@ -220,9 +223,10 @@ impl GraphPage {
 
 	// TODO: make trait-based
 	/// Convert to an encrypted binary payload according to the DSNP Private Graph schema
-	pub fn to_private_page_data<E: EncryptionBehavior>(
+	pub fn to_private_page_data(
 		&self,
-		(key_id, key): (u64, &PublicKey<E>),
+		dsnp_version_config: &DsnpVersionConfig,
+		key: &ResolvedKeyPair,
 		_prid_keys: &Vec<DsnpKeys>,
 	) -> Result<PageData> {
 		if self.privacy_type != PrivacyType::Private {
@@ -235,9 +239,11 @@ impl GraphPage {
 		let DsnpUserPublicGraphChunk { compressed_public_graph } =
 			self.connections.clone().try_into()?;
 		let private_chunk = DsnpUserPrivateGraphChunk {
-			key_id,
+			key_id: key.clone().key_id,
 			prids: self.prids.clone(),
-			encrypted_compressed_private_graph: E::encrypt(&compressed_public_graph, key)?,
+			encrypted_compressed_private_graph: dsnp_version_config
+				.get_algorithm()
+				.encrypt(&compressed_public_graph, &key.key_pair.clone().into())?,
 		};
 
 		Ok(PageData {

--- a/core/src/graph/page.rs
+++ b/core/src/graph/page.rs
@@ -3,6 +3,7 @@ use crate::{
 	util::time::time_in_ksecs,
 };
 use anyhow::{Error, Result};
+use std::borrow::Borrow;
 
 use crate::dsnp::{
 	compression::{CompressionBehavior, DeflateCompression},
@@ -14,7 +15,7 @@ use crate::dsnp::{
 const APPROX_MAX_CONNECTIONS_PER_PAGE: usize = 10; // todo: determine best size for this
 
 /// Graph page structure
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GraphPage {
 	/// Page ID
 	page_id: PageId,
@@ -243,7 +244,7 @@ impl GraphPage {
 			prids: self.prids.clone(),
 			encrypted_compressed_private_graph: dsnp_version_config
 				.get_algorithm()
-				.encrypt(&compressed_public_graph, &key.key_pair.clone().into())?,
+				.encrypt(&compressed_public_graph, &key.key_pair.borrow().into())?,
 		};
 
 		Ok(PageData {


### PR DESCRIPTION
# Goal
The goal of this PR is support new keys and dsnp versions in graph sdk.

Closes #34 

# What is changed and why?
- Removed associated attributes on EncryptionBehavior since it was causing a lot rigidity and causing issue with conversion between associated attribute and concrete type, preventing for dynamic dispatch
- Replaced encryption and key types generics with Enums since it is allowing more flexibility and decoupling between dsnp version and key types for future
- Removed dsnp configuration from our config json since we would need to have them as static enums and it didn't make sense to have them dynamically
- moved some of hardcoded constants into config json
