### PR TITLE
api to expose imported public keys

### DIFF
--- a/bridge/ffi/src/bindings.rs
+++ b/bridge/ffi/src/bindings.rs
@@ -13,6 +13,21 @@ pub struct KeyData {
 	pub content_len: size_t,
 }
 
+/// `dsnp_graph_core::dsnp::dsnp_types::DsnpPublicKey` type
+#[repr(C)]
+pub struct DsnpPublicKey {
+	pub key_id: u64,
+	pub content: *mut u8,
+	pub content_len: size_t,
+}
+
+// Output type for DsnpPublicKey list
+#[repr(C)]
+pub struct DsnpPublicKeys {
+	pub keys: *mut DsnpPublicKey,
+	pub keys_len: usize,
+}
+
 /// `dsnp_graph_core::dsnp::api_types::GraphKeyPair` type
 #[repr(C)]
 pub struct GraphKeyPair {

--- a/bridge/ffi/src/c_example/main.c
+++ b/bridge/ffi/src/c_example/main.c
@@ -61,6 +61,9 @@ int test_graph_sdk_ffi() {
     GraphConnections one_sided_connections = graph_get_one_sided_private_friendship_connections(graph_state, &user_id);
     ASSERT(one_sided_connections.connections_len == 0, "Failed to get one-sided private friendship connections");
 
+    DsnpPublicKeys public_keys = graph_get_public_keys(graph_state, &user_id);
+    ASSERT(public_keys.keys_len == 0, "Failed to get dsnp public keys");
+
     // Clean up and free the graph state
     free_graph_state(graph_state);
 

--- a/bridge/ffi/src/utils.rs
+++ b/bridge/ffi/src/utils.rs
@@ -208,3 +208,15 @@ pub fn actions_from_ffi(actions: &[Action]) -> Vec<dsnp_graph_core::dsnp::api_ty
 	}
 	rust_actions
 }
+
+pub fn dsnp_public_keys_to_ffi(
+	keys: Vec<dsnp_graph_core::dsnp::dsnp_types::DsnpPublicKey>,
+) -> Vec<DsnpPublicKey> {
+	keys.into_iter()
+		.map(|key| DsnpPublicKey {
+			key_id: key.key_id.unwrap(), // unwrap is fine since it should be always populated
+			content_len: key.key.len(),
+			content: ManuallyDrop::new(key.key).as_mut_ptr(),
+		})
+		.collect()
+}

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -1,7 +1,7 @@
 use crate::{
 	dsnp::{
 		api_types::{Action, Connection, ImportBundle, PrivacyType, Update},
-		dsnp_types::{DsnpGraphEdge, DsnpUserId},
+		dsnp_types::{DsnpGraphEdge, DsnpPublicKey, DsnpUserId},
 	},
 	graph::{
 		key_manager::UserKeyProvider,
@@ -69,6 +69,9 @@ pub trait GraphAPI {
 		&self,
 		user_id: &DsnpUserId,
 	) -> Result<Vec<DsnpGraphEdge>>;
+
+	/// Get a list published and imported public keys associated with a user
+	fn get_public_keys(&self, user_id: &DsnpUserId) -> Result<Vec<DsnpPublicKey>>;
 }
 
 impl Transactional for GraphState {
@@ -214,6 +217,15 @@ impl GraphAPI for GraphState {
 		};
 		let graph = user_graph.graph(&private_friendship_schema_id);
 		graph.get_one_sided_friendships()
+	}
+
+	/// Get a list published and imported public keys associated with a user
+	fn get_public_keys(&self, user_id: &DsnpUserId) -> Result<Vec<DsnpPublicKey>> {
+		Ok(self
+			.shared_state_manager
+			.read()
+			.map_err(|_| Error::msg("Error getting read lock for shared_state_manager!"))?
+			.get_public_keys(user_id))
 	}
 }
 

--- a/core/src/graph/shared_state_manager.rs
+++ b/core/src/graph/shared_state_manager.rs
@@ -278,6 +278,13 @@ impl SharedStateManager {
 			.collect()
 	}
 
+	pub fn get_public_keys(&self, dsnp_user_id: &DsnpUserId) -> Vec<DsnpPublicKey> {
+		match self.dsnp_user_to_keys.get(dsnp_user_id) {
+			Some((keys, _)) => keys.iter().cloned().collect(),
+			None => Vec::new(),
+		}
+	}
+
 	fn get_next_key_id(&self, dsnp_user_id: DsnpUserId) -> u64 {
 		self.get_imported_keys(dsnp_user_id)
 			.iter()


### PR DESCRIPTION
# Goal
The goal of this PR is provide an api to expose imported public keys

Closes #69 

# Checklist
- [x] FFI binding added 
- [x] Tests added

