### PR TITLE
implemented jni apis

### DIFF
--- a/bridge/jni/src/api.rs
+++ b/bridge/jni/src/api.rs
@@ -1,11 +1,19 @@
-use crate::mappings::map_to_environment;
-use dsnp_graph_core::api::api::GraphState;
+use crate::mappings::{
+	convert_jboolean, map_to_actions, map_to_environment, map_to_imports, serialize_config,
+	serialize_dsnp_users, serialize_graph_edges, serialize_graph_updates, serialize_public_keys,
+};
+use dsnp_graph_config::{DsnpUserId, SchemaId};
+use dsnp_graph_core::api::api::{GraphAPI, GraphState};
 use jni::{
 	objects::{JByteArray, JClass, JObject, JString},
-	sys::{jboolean, jint, jlong},
+	sys::{jboolean, jint, jlong, JNI_ERR, JNI_FALSE},
 	JNIEnv,
 };
-use std::{panic, sync::Mutex};
+use std::{
+	ops::{Deref, DerefMut},
+	panic,
+	sync::Mutex,
+};
 
 // Collection of GraphStates
 static GRAPH_STATES: Mutex<Vec<jlong>> = Mutex::new(Vec::new());
@@ -76,120 +84,295 @@ pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_freeGraphState<'local>(
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_getConfig<'local>(
-	mut _env: JNIEnv<'local>,
+	env: JNIEnv<'local>,
 	_class: JClass<'local>,
-	_environment: JByteArray,
+	environment: JByteArray,
 ) -> JByteArray<'local> {
-	unimplemented!("Java_io_amplica_graphsdk_Native_getConfig")
+	let result = panic::catch_unwind(|| {
+		let rust_environment = map_to_environment(&env, &environment).unwrap();
+		let config = rust_environment.get_config();
+		let result = serialize_config(&env, &config).unwrap();
+		result
+	});
+	result.unwrap_or(JByteArray::default())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_containsUserGraph<'local>(
 	mut _env: JNIEnv<'local>,
 	_class: JClass<'local>,
-	_handle: jlong,
-	_dsnp_user_id: jlong,
+	handle: jlong,
+	dsnp_user_id: jlong,
 ) -> jboolean {
-	unimplemented!("Java_io_amplica_graphsdk_Native_containsUserGraph")
+	let result = panic::catch_unwind(|| {
+		if handle == 0 {
+			return JNI_FALSE
+		}
+		let graph_states = GRAPH_STATES.lock().unwrap();
+		if !graph_states.contains(&handle) {
+			return JNI_FALSE
+		}
+		let graph = unsafe { Box::from_raw(handle as *mut GraphState) };
+		// TODO: test edge case that dsnp_user_id is bigger than i64
+		let user_id = u64::try_from(dsnp_user_id).unwrap();
+		let result = graph.deref().contains_user_graph(&user_id).into();
+		// pulling out of the box as raw so that memory stays allocated
+		let _ = Box::into_raw(graph) as jlong;
+		result
+	});
+	result.unwrap_or(JNI_FALSE)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_getGraphUsersLength<'local>(
 	mut _env: JNIEnv<'local>,
 	_class: JClass<'local>,
-	_handle: jlong,
+	handle: jlong,
 ) -> jint {
-	unimplemented!("Java_io_amplica_graphsdk_Native_getGraphUsersLength")
+	let result = panic::catch_unwind(|| {
+		if handle == 0 {
+			return JNI_ERR
+		}
+		let graph_states = GRAPH_STATES.lock().unwrap();
+		if !graph_states.contains(&handle) {
+			return JNI_ERR
+		}
+		let graph = unsafe { Box::from_raw(handle as *mut GraphState) };
+		let result = graph.deref().len() as jint;
+		// pulling out of the box as raw so that memory stays allocated
+		let _ = Box::into_raw(graph) as jlong;
+		result
+	});
+	result.unwrap_or(JNI_ERR)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_removeUserGraph<'local>(
 	mut _env: JNIEnv<'local>,
 	_class: JClass<'local>,
-	_handle: jlong,
-	_dsnp_user_id: jlong,
+	handle: jlong,
+	dsnp_user_id: jlong,
 ) {
-	unimplemented!("Java_io_amplica_graphsdk_Native_removeUserGraph")
+	let _ = panic::catch_unwind(|| {
+		if handle == 0 {
+			return
+		}
+		let graph_states = GRAPH_STATES.lock().unwrap();
+		if !graph_states.contains(&handle) {
+			return
+		}
+		let mut graph = unsafe { Box::from_raw(handle as *mut GraphState) };
+		let user_id = u64::try_from(dsnp_user_id).unwrap();
+		graph.deref_mut().remove_user_graph(&user_id);
+		// pulling out of the box as raw so that memory stays allocated
+		let _ = Box::into_raw(graph) as jlong;
+	});
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_importUserData<'local>(
-	mut _env: JNIEnv<'local>,
+	env: JNIEnv<'local>,
 	_class: JClass<'local>,
-	_handle: jlong,
-	_import: JByteArray,
-) -> JByteArray<'local> {
-	unimplemented!("Java_io_amplica_graphsdk_Native_importUserData")
+	handle: jlong,
+	imports: JByteArray,
+) {
+	let _ = panic::catch_unwind(|| {
+		if handle == 0 {
+			return
+		}
+		let graph_states = GRAPH_STATES.lock().unwrap();
+		if !graph_states.contains(&handle) {
+			return
+		}
+		let mut graph = unsafe { Box::from_raw(handle as *mut GraphState) };
+		let rust_imports = map_to_imports(&env, &imports).unwrap();
+		graph.deref_mut().import_users_data(&rust_imports).unwrap();
+		// pulling out of the box as raw so that memory stays allocated
+		let _ = Box::into_raw(graph) as jlong;
+	});
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_exportUpdates<'local>(
-	mut _env: JNIEnv<'local>,
+	env: JNIEnv<'local>,
 	_class: JClass<'local>,
-	_handle: jlong,
+	handle: jlong,
 ) -> JByteArray<'local> {
-	unimplemented!("Java_io_amplica_graphsdk_Native_exportUpdates")
+	let result = panic::catch_unwind(|| {
+		if handle == 0 {
+			return JByteArray::default()
+		}
+		let graph_states = GRAPH_STATES.lock().unwrap();
+		if !graph_states.contains(&handle) {
+			return JByteArray::default()
+		}
+		let graph = unsafe { Box::from_raw(handle as *mut GraphState) };
+		let updates = graph.deref().export_updates().unwrap();
+		let result = serialize_graph_updates(&env, &updates).unwrap();
+		// pulling out of the box as raw so that memory stays allocated
+		let _ = Box::into_raw(graph) as jlong;
+		result
+	});
+	result.unwrap_or(JByteArray::default())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_applyActions<'local>(
-	mut _env: JNIEnv<'local>,
+	env: JNIEnv<'local>,
 	_class: JClass<'local>,
-	_handle: jlong,
-	_actions: JByteArray,
+	handle: jlong,
+	actions: JByteArray,
 ) {
-	unimplemented!("Java_io_amplica_graphsdk_Native_applyActions")
+	let _ = panic::catch_unwind(|| {
+		if handle == 0 {
+			return
+		}
+		let actions = map_to_actions(&env, &actions).unwrap();
+		let graph_states = GRAPH_STATES.lock().unwrap();
+		if !graph_states.contains(&handle) {
+			return
+		}
+		let mut graph = unsafe { Box::from_raw(handle as *mut GraphState) };
+		graph.deref_mut().apply_actions(&actions).unwrap();
+		// pulling out of the box as raw so that memory stays allocated
+		let _ = Box::into_raw(graph) as jlong;
+	});
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_forceCalculateGraphs<'local>(
-	mut _env: JNIEnv<'local>,
+	env: JNIEnv<'local>,
 	_class: JClass<'local>,
-	_handle: jlong,
-	_dsnp_user_id: jlong,
+	handle: jlong,
+	dsnp_user_id: jlong,
 ) -> JByteArray<'local> {
-	unimplemented!("Java_io_amplica_graphsdk_Native_forceCalculateGraphs")
+	let result = panic::catch_unwind(|| {
+		if handle == 0 {
+			return JByteArray::default()
+		}
+		let graph_states = GRAPH_STATES.lock().unwrap();
+		if !graph_states.contains(&handle) {
+			return JByteArray::default()
+		}
+		let graph = unsafe { Box::from_raw(handle as *mut GraphState) };
+		let dsnp_user_id = DsnpUserId::try_from(dsnp_user_id).unwrap();
+		let updates = graph.deref().force_recalculate_graphs(&dsnp_user_id).unwrap();
+		let result = serialize_graph_updates(&env, &updates).unwrap();
+		// pulling out of the box as raw so that memory stays allocated
+		let _ = Box::into_raw(graph) as jlong;
+		result
+	});
+	result.unwrap_or(JByteArray::default())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_getConnectionsForUserGraph<'local>(
-	mut _env: JNIEnv<'local>,
+	env: JNIEnv<'local>,
 	_class: JClass<'local>,
-	_handle: jlong,
-	_dsnp_user_id: jlong,
-	_schema_id: jint,
-	_include_pending: jboolean,
+	handle: jlong,
+	dsnp_user_id: jlong,
+	schema_id: jint,
+	include_pending: jboolean,
 ) -> JByteArray<'local> {
-	unimplemented!("Java_io_amplica_graphsdk_Native_getConnectionsForUserGraph")
+	let result = panic::catch_unwind(|| {
+		if handle == 0 {
+			return JByteArray::default()
+		}
+		let graph_states = GRAPH_STATES.lock().unwrap();
+		if !graph_states.contains(&handle) {
+			return JByteArray::default()
+		}
+		let graph = unsafe { Box::from_raw(handle as *mut GraphState) };
+		let dsnp_user_id = DsnpUserId::try_from(dsnp_user_id).unwrap();
+		let schema_id = SchemaId::try_from(schema_id).unwrap();
+		let include_pending = convert_jboolean(include_pending).unwrap();
+		let graph_edges = graph
+			.deref()
+			.get_connections_for_user_graph(&dsnp_user_id, &schema_id, include_pending)
+			.unwrap();
+		let result = serialize_graph_edges(&env, &graph_edges).unwrap();
+		// pulling out of the box as raw so that memory stays allocated
+		let _ = Box::into_raw(graph) as jlong;
+		result
+	});
+	result.unwrap_or(JByteArray::default())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_getUsersWithoutKeys<'local>(
-	mut _env: JNIEnv<'local>,
+	env: JNIEnv<'local>,
 	_class: JClass<'local>,
-	_handle: jlong,
+	handle: jlong,
 ) -> JByteArray<'local> {
-	unimplemented!("Java_io_amplica_graphsdk_Native_getUsersWithoutKeys")
+	let result = panic::catch_unwind(|| {
+		if handle == 0 {
+			return JByteArray::default()
+		}
+		let graph_states = GRAPH_STATES.lock().unwrap();
+		if !graph_states.contains(&handle) {
+			return JByteArray::default()
+		}
+		let graph = unsafe { Box::from_raw(handle as *mut GraphState) };
+		let dsnp_users = graph.deref().get_connections_without_keys().unwrap();
+		let result = serialize_dsnp_users(&env, &dsnp_users).unwrap();
+		// pulling out of the box as raw so that memory stays allocated
+		let _ = Box::into_raw(graph) as jlong;
+		result
+	});
+	result.unwrap_or(JByteArray::default())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_getOneSidedPrivateFriendshipConnections<
 	'local,
 >(
-	mut _env: JNIEnv<'local>,
+	env: JNIEnv<'local>,
 	_class: JClass<'local>,
-	_handle: jlong,
-	_dsnp_user_id: jlong,
+	handle: jlong,
+	dsnp_user_id: jlong,
 ) -> JByteArray<'local> {
-	unimplemented!("Java_io_amplica_graphsdk_Native_getConnectionsForUserGraph")
+	let result = panic::catch_unwind(|| {
+		if handle == 0 {
+			return JByteArray::default()
+		}
+		let graph_states = GRAPH_STATES.lock().unwrap();
+		if !graph_states.contains(&handle) {
+			return JByteArray::default()
+		}
+		let graph = unsafe { Box::from_raw(handle as *mut GraphState) };
+		let user_id = u64::try_from(dsnp_user_id).unwrap();
+		let graph_edges =
+			graph.deref().get_one_sided_private_friendship_connections(&user_id).unwrap();
+		let result = serialize_graph_edges(&env, &graph_edges).unwrap();
+		// pulling out of the box as raw so that memory stays allocated
+		let _ = Box::into_raw(graph) as jlong;
+		result
+	});
+	result.unwrap_or(JByteArray::default())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_amplica_graphsdk_Native_getPublicKeys<'local>(
-	mut _env: JNIEnv<'local>,
+	env: JNIEnv<'local>,
 	_class: JClass<'local>,
-	_handle: jlong,
-	_dsnp_user_id: jlong,
+	handle: jlong,
+	dsnp_user_id: jlong,
 ) -> JByteArray<'local> {
-	unimplemented!("Java_io_amplica_graphsdk_Native_getConnectionsForUserGraph")
+	let result = panic::catch_unwind(|| {
+		if handle == 0 {
+			return JByteArray::default()
+		}
+		let graph_states = GRAPH_STATES.lock().unwrap();
+		if !graph_states.contains(&handle) {
+			return JByteArray::default()
+		}
+		let graph = unsafe { Box::from_raw(handle as *mut GraphState) };
+		let user_id = u64::try_from(dsnp_user_id).unwrap();
+		let public_keys = graph.deref().get_public_keys(&user_id).unwrap();
+		let result = serialize_public_keys(&env, &public_keys).unwrap();
+		// pulling out of the box as raw so that memory stays allocated
+		let _ = Box::into_raw(graph) as jlong;
+		result
+	});
+	result.unwrap_or(JByteArray::default())
 }

--- a/bridge/jni/src/mappings.rs
+++ b/bridge/jni/src/mappings.rs
@@ -1,13 +1,30 @@
 use dsnp_graph_config::{
-	Config as RustConfig, DsnpVersion as RustDsnpVersion, Environment as RustEnvironment,
-	SchemaConfig as RustSchemaConfig, SchemaId,
+	Config as RustConfig, DsnpUserId, DsnpVersion as RustDsnpVersion,
+	Environment as RustEnvironment, GraphKeyType as RustGraphKeyType, PageId,
+	SchemaConfig as RustSchemaConfig, SchemaConfig, SchemaId,
 };
-use dsnp_graph_core::dsnp::api_types::{
-	ConnectionType as RustConnectionType, PrivacyType as RustPrivacyType,
+use dsnp_graph_core::dsnp::{
+	api_types::{
+		Action as RustAction, Connection as RustConnection, ConnectionType as RustConnectionType,
+		DsnpKeys as RustDsnpKeys, GraphKeyPair as RustGraphKeyPair,
+		ImportBundle as RustImportBundle, KeyData as RustKeyData, PageData as RustPageData,
+		PrivacyType as RustPrivacyType, Update as RustUpdate,
+	},
+	dsnp_types::{DsnpGraphEdge as RustDsnpGraphEdge, DsnpPublicKey as RustDsnpPublicKey},
 };
-use dsnp_graph_sdk_common::proto_types::output as proto_output;
-use jni::{objects::JByteArray, JNIEnv};
-use protobuf::Message;
+use dsnp_graph_sdk_common::proto_types::{
+	input as proto_input,
+	output::{
+		self as proto_output,
+		updates::update::{AddKeyUpdate, DeletePageUpdate, PersistPageUpdate},
+	},
+};
+use jni::{
+	objects::JByteArray,
+	sys::{jboolean, JNI_FALSE, JNI_TRUE},
+	JNIEnv,
+};
+use protobuf::{EnumOrUnknown, Message, SpecialFields};
 use std::collections::HashMap;
 
 pub fn map_to_environment<'local>(
@@ -26,6 +43,187 @@ pub fn map_to_environment<'local>(
 		},
 	};
 	Some(result)
+}
+
+pub fn map_to_actions<'local>(
+	env: &JNIEnv<'local>,
+	actions: &JByteArray,
+) -> Option<Vec<RustAction>> {
+	let bytes = env.convert_byte_array(actions).ok()?;
+	let actions_proto = proto_input::Actions::parse_from_bytes(&bytes).ok()?;
+
+	let mut result = vec![];
+	for a in actions_proto.actions {
+		result.push(map_action_to_rust(a)?);
+	}
+	Some(result)
+}
+
+pub fn map_to_imports<'local>(
+	env: &JNIEnv<'local>,
+	imports: &JByteArray,
+) -> Option<Vec<RustImportBundle>> {
+	let bytes = env.convert_byte_array(imports).ok()?;
+	let imports_proto = proto_input::ImportBundles::parse_from_bytes(&bytes).ok()?;
+	let mut result = vec![];
+	for i in imports_proto.bundles {
+		result.push(RustImportBundle {
+			schema_id: SchemaId::try_from(i.schema_id).ok()?,
+			dsnp_user_id: i.dsnp_user_id,
+			dsnp_keys: map_dsnp_keys_to_rust(i.dsnp_keys.as_ref()?)?,
+			key_pairs: map_graph_key_pairs_to_rust(&i.key_pairs)?,
+			pages: map_page_datas_to_rust(&i.pages)?,
+		});
+	}
+	Some(result)
+}
+
+pub fn serialize_public_keys<'local>(
+	env: &JNIEnv<'local>,
+	public_keys: &[RustDsnpPublicKey],
+) -> Option<JByteArray<'local>> {
+	let mut proto_keys = vec![];
+	for k in public_keys {
+		proto_keys.push(proto_output::dsnp_public_keys::DsnpPublicKey {
+			key: k.key.clone(),
+			key_id: k.key_id?,
+			special_fields: SpecialFields::default(),
+		});
+	}
+	let all_keys = proto_output::DsnpPublicKeys {
+		public_key: proto_keys,
+		special_fields: SpecialFields::default(),
+	};
+
+	let bytes = all_keys.write_to_bytes().ok()?;
+	let arr = env.byte_array_from_slice(&bytes).ok()?;
+	Some(arr)
+}
+
+pub fn serialize_graph_edges<'local>(
+	env: &JNIEnv<'local>,
+	graph_edge: &[RustDsnpGraphEdge],
+) -> Option<JByteArray<'local>> {
+	let mut proto_edge = vec![];
+	for e in graph_edge {
+		proto_edge.push(proto_output::dsnp_graph_edges::DsnpGraphEdge {
+			user_id: e.user_id,
+			since: e.since,
+			special_fields: SpecialFields::default(),
+		});
+	}
+	let all_edges =
+		proto_output::DsnpGraphEdges { edge: proto_edge, special_fields: SpecialFields::default() };
+
+	let bytes = all_edges.write_to_bytes().ok()?;
+	let arr = env.byte_array_from_slice(&bytes).ok()?;
+	Some(arr)
+}
+
+pub fn serialize_graph_updates<'local>(
+	env: &JNIEnv<'local>,
+	updates: &[RustUpdate],
+) -> Option<JByteArray<'local>> {
+	let mut protos = vec![];
+	for e in updates {
+		protos.push(map_update_to_proto(e)?);
+	}
+	let all_updates =
+		proto_output::Updates { update: protos, special_fields: SpecialFields::default() };
+
+	let bytes = all_updates.write_to_bytes().ok()?;
+	let arr = env.byte_array_from_slice(&bytes).ok()?;
+	Some(arr)
+}
+
+pub fn serialize_config<'local>(
+	env: &JNIEnv<'local>,
+	config: &RustConfig,
+) -> Option<JByteArray<'local>> {
+	let proto = proto_output::Config {
+		max_page_id: config.max_page_id,
+		max_key_page_size_bytes: config.max_key_page_size_bytes,
+		sdk_max_users_graph_size: config.sdk_max_users_graph_size,
+		sdk_max_stale_friendship_days: config.sdk_max_stale_friendship_days,
+		max_graph_page_size_bytes: config.max_graph_page_size_bytes,
+		dsnp_versions: map_dsnp_versions_to_proto(&config.dsnp_versions)?,
+		schema_map: map_schema_map_to_proto(&config.schema_map)?,
+		special_fields: SpecialFields::default(),
+	};
+
+	let bytes = proto.write_to_bytes().ok()?;
+	let arr = env.byte_array_from_slice(&bytes).ok()?;
+	Some(arr)
+}
+
+pub fn serialize_dsnp_users<'local>(
+	env: &JNIEnv<'local>,
+	dsnp_users: &[DsnpUserId],
+) -> Option<JByteArray<'local>> {
+	let mut proto = vec![];
+	for e in dsnp_users {
+		proto.push(*e);
+	}
+	let users = proto_output::DsnpUsers { user: proto, special_fields: SpecialFields::default() };
+
+	let bytes = users.write_to_bytes().ok()?;
+	let arr = env.byte_array_from_slice(&bytes).ok()?;
+	Some(arr)
+}
+
+pub fn convert_jboolean(b: jboolean) -> Option<bool> {
+	match b {
+		JNI_FALSE => Some(false),
+		JNI_TRUE => Some(true),
+		_ => None,
+	}
+}
+
+fn map_action_to_rust(action: proto_input::actions::Action) -> Option<RustAction> {
+	let unwrapped = action.inner?;
+	Some(match unwrapped {
+		proto_input::actions::action::Inner::AddKeyAction(add_key) => RustAction::AddGraphKey {
+			owner_dsnp_user_id: add_key.owner_dsnp_user_id,
+			new_public_key: add_key.new_public_key,
+		},
+		proto_input::actions::action::Inner::ConnectAction(connect) => RustAction::Connect {
+			owner_dsnp_user_id: connect.owner_dsnp_user_id,
+			connection: map_connection_to_rust(connect.connection.as_ref()?)?,
+			dsnp_keys: match connect.dsnp_keys.as_ref() {
+				Some(k) => Some(map_dsnp_keys_to_rust(k)?),
+				None => None,
+			},
+		},
+		proto_input::actions::action::Inner::DisconnectAction(disconnect) =>
+			RustAction::Disconnect {
+				owner_dsnp_user_id: disconnect.owner_dsnp_user_id,
+				connection: map_connection_to_rust(disconnect.connection.as_ref()?)?,
+			},
+		_ => return None,
+	})
+}
+
+fn map_connection_to_rust(conection: &proto_input::Connection) -> Option<RustConnection> {
+	Some(RustConnection {
+		dsnp_user_id: conection.dsnp_user_id,
+		schema_id: SchemaId::try_from(conection.schema_id).ok()?,
+	})
+}
+
+fn map_dsnp_keys_to_rust(dsnp_keys: &proto_input::DsnpKeys) -> Option<RustDsnpKeys> {
+	Some(RustDsnpKeys {
+		dsnp_user_id: dsnp_keys.dsnp_user_id,
+		keys_hash: dsnp_keys.keys_hash,
+		keys: map_key_data_to_rust(&dsnp_keys.keys)?,
+	})
+}
+
+fn map_key_data_to_rust(key_datas: &Vec<proto_input::KeyData>) -> Option<Vec<RustKeyData>> {
+	let mut keys = vec![];
+	for k in key_datas {
+		keys.push(RustKeyData { content: k.content.clone(), index: u16::try_from(k.index).ok()? });
+	}
+	Some(keys)
 }
 
 fn map_config_to_rust(config: proto_output::Config) -> Option<RustConfig> {
@@ -83,5 +281,120 @@ fn map_connection_type_to_rust(
 			RustConnectionType::Friendship(RustPrivacyType::Private),
 		proto_output::ConnectionType::FriendshipPublic =>
 			RustConnectionType::Friendship(RustPrivacyType::Public),
+	})
+}
+
+fn map_update_to_proto(update: &RustUpdate) -> Option<proto_output::updates::Update> {
+	let mut proto = proto_output::updates::Update::new();
+	let inner = match update {
+		RustUpdate::PersistPage { schema_id, page_id, prev_hash, owner_dsnp_user_id, payload } =>
+			proto_output::updates::update::Inner::Persist(PersistPageUpdate {
+				owner_dsnp_user_id: *owner_dsnp_user_id,
+				prev_hash: *prev_hash,
+				page_id: u32::try_from(*page_id).ok()?,
+				schema_id: u32::try_from(*schema_id).ok()?,
+				payload: payload.clone(),
+				special_fields: SpecialFields::default(),
+			}),
+		RustUpdate::DeletePage { schema_id, page_id, prev_hash, owner_dsnp_user_id } =>
+			proto_output::updates::update::Inner::Delete(DeletePageUpdate {
+				owner_dsnp_user_id: *owner_dsnp_user_id,
+				prev_hash: *prev_hash,
+				page_id: u32::try_from(*page_id).ok()?,
+				schema_id: u32::try_from(*schema_id).ok()?,
+				special_fields: SpecialFields::default(),
+			}),
+		RustUpdate::AddKey { prev_hash, owner_dsnp_user_id, payload } =>
+			proto_output::updates::update::Inner::AddKey(AddKeyUpdate {
+				owner_dsnp_user_id: *owner_dsnp_user_id,
+				prev_hash: *prev_hash,
+				payload: payload.clone(),
+				special_fields: SpecialFields::default(),
+			}),
+	};
+	proto.inner = Some(inner);
+	Some(proto)
+}
+
+fn map_graph_key_pairs_to_rust(
+	key_pairs: &[proto_input::import_bundles::import_bundle::GraphKeyPair],
+) -> Option<Vec<RustGraphKeyPair>> {
+	let mut result = vec![];
+	for p in key_pairs {
+		result.push(RustGraphKeyPair {
+			public_key: p.public_key.clone(),
+			secret_key: p.secret_key.clone(),
+			key_type: map_graph_key_type_to_rust(p.key_type.enum_value().ok()?)?,
+		})
+	}
+	Some(result)
+}
+
+fn map_graph_key_type_to_rust(key_type: proto_input::GraphKeyType) -> Option<RustGraphKeyType> {
+	Some(match key_type {
+		proto_input::GraphKeyType::X25519 => RustGraphKeyType::X25519,
+	})
+}
+
+fn map_page_datas_to_rust(pages: &[proto_input::PageData]) -> Option<Vec<RustPageData>> {
+	let mut result = vec![];
+	for p in pages {
+		result.push(RustPageData {
+			page_id: PageId::try_from(p.page_id).ok()?,
+			content_hash: p.content_hash,
+			content: p.content.clone(),
+		})
+	}
+	Some(result)
+}
+
+fn map_dsnp_versions_to_proto(
+	versions: &Vec<RustDsnpVersion>,
+) -> Option<Vec<EnumOrUnknown<proto_output::DsnpVersion>>> {
+	let mut result = vec![];
+	for v in versions {
+		result.push(map_dsnp_version_to_proto(v)?);
+	}
+	Some(result)
+}
+
+fn map_dsnp_version_to_proto(
+	version: &RustDsnpVersion,
+) -> Option<EnumOrUnknown<proto_output::DsnpVersion>> {
+	Some(match version {
+		RustDsnpVersion::Version1_0 => EnumOrUnknown::new(proto_output::DsnpVersion::Version1_0),
+	})
+}
+
+fn map_connection_type_to_proto(
+	connection_type: &RustConnectionType,
+) -> Option<EnumOrUnknown<proto_output::ConnectionType>> {
+	Some(match connection_type {
+		RustConnectionType::Friendship(RustPrivacyType::Private) =>
+			EnumOrUnknown::new(proto_output::ConnectionType::FriendshipPrivate),
+		RustConnectionType::Friendship(RustPrivacyType::Public) =>
+			EnumOrUnknown::new(proto_output::ConnectionType::FriendshipPublic),
+		RustConnectionType::Follow(RustPrivacyType::Private) =>
+			EnumOrUnknown::new(proto_output::ConnectionType::FollowPrivate),
+		RustConnectionType::Follow(RustPrivacyType::Public) =>
+			EnumOrUnknown::new(proto_output::ConnectionType::FollowPublic),
+	})
+}
+
+fn map_schema_map_to_proto(
+	map: &HashMap<SchemaId, SchemaConfig>,
+) -> Option<HashMap<u32, proto_output::SchemaConfig>> {
+	let mut result = HashMap::new();
+	for (k, v) in map {
+		result.insert(u32::try_from(*k).ok()?, map_schema_config_to_proto(v)?);
+	}
+	Some(result)
+}
+
+fn map_schema_config_to_proto(schema_config: &SchemaConfig) -> Option<proto_output::SchemaConfig> {
+	Some(proto_output::SchemaConfig {
+		dsnp_version: map_dsnp_version_to_proto(&schema_config.dsnp_version)?,
+		connection_type: map_connection_type_to_proto(&schema_config.connection_type)?,
+		special_fields: SpecialFields::default(),
 	})
 }

--- a/java/lib/src/main/java/io/amplica/graphsdk/Graph.java
+++ b/java/lib/src/main/java/io/amplica/graphsdk/Graph.java
@@ -10,73 +10,57 @@ public class Graph implements NativeHandleGuard.Owner {
     private final long unsafeHandle;
     private final Configuration configuration;
 
-    public Graph(Environment environment) {
-        this.unsafeHandle = Native.initializeGraphState(environment.toByteArray());
-        this.configuration = null;
+    public Graph(Configuration configuration) {
+        this.configuration = configuration;
+        this.unsafeHandle = Native.initializeGraphState(configuration.getEnvironment().toByteArray());
     }
 
-    // TODO replace this after
-    public Graph(Environment environment, Configuration configuration) {
-        this(environment);
-//        this.configuration = configuration; TODO: uncomment and assign after jni implementation
-    }
-
-    // TODO: create tests after jni implementation
     public boolean containsUserGraph(long dsnpUserId) throws Exception {
         return Native.containsUserGraph(this.unsafeHandle, dsnpUserId);
     }
 
-    // TODO: create tests after jni implementation
     public int getUsersLength() throws Exception {
         return Native.getGraphUsersLength(this.unsafeHandle);
     }
 
-    // TODO: create tests after jni implementation
     public void removeUserGraph(long dsnpUserId) throws Exception {
         Native.removeUserGraph(this.unsafeHandle, dsnpUserId);
     }
 
-    // TODO: create tests after jni implementation
     public void importUserData(ImportBundles bundle) throws Exception {
         Native.importUserData(this.unsafeHandle, bundle.toByteArray());
     }
 
-    // TODO: create tests after jni implementation
     public List<Updates.Update> exportUpdates() throws Exception {
         var raw = Native.exportUpdates(this.unsafeHandle);
         return Updates.parseFrom(raw).getUpdateList();
     }
 
-    // TODO: create tests after jni implementation
     public void applyActions(Actions actions) throws Exception {
         Native.applyActions(this.unsafeHandle, actions.toByteArray());
     }
 
-    // TODO: create tests after jni implementation
     public List<Updates.Update> forceRecalculateGraph(long dsnpUserId) throws Exception {
         var raw = Native.forceCalculateGraphs(this.unsafeHandle, dsnpUserId);
         return Updates.parseFrom(raw).getUpdateList();
     }
 
-    // TODO: create tests after jni implementation
     public List<DsnpGraphEdges.DsnpGraphEdge> getConnections(long dsnpUserId, ConnectionType connectionType, boolean includePending) throws InvalidProtocolBufferException {
         var raw = Native.getConnectionsForUserGraph(this.unsafeHandle, dsnpUserId, this.configuration.getSchemaId(connectionType), includePending);
         return DsnpGraphEdges.parseFrom(raw).getEdgeList();
     }
 
-    // TODO: create tests after jni implementation
     public List<Long> getUsersWithoutImportedKeys() throws InvalidProtocolBufferException {
         var raw = Native.getUsersWithoutKeys(this.unsafeHandle);
         return DsnpUsers.parseFrom(raw).getUserList();
     }
 
-    // TODO: create tests after jni implementation
+    // TODO: add test
     public List<DsnpGraphEdges.DsnpGraphEdge> getOneSidedPrivateFriendships(long dsnpUserId) throws InvalidProtocolBufferException {
         var raw = Native.getOneSidedPrivateFriendshipConnections(this.unsafeHandle, dsnpUserId);
         return DsnpGraphEdges.parseFrom(raw).getEdgeList();
     }
 
-    // TODO: create tests after jni implementation
     public List<DsnpPublicKeys.DsnpPublicKey> getPublicKeys(long dsnpUserId) throws InvalidProtocolBufferException {
         var raw = Native.getPublicKeys(this.unsafeHandle, dsnpUserId);
         return DsnpPublicKeys.parseFrom(raw).getPublicKeyList();
@@ -87,7 +71,8 @@ public class Graph implements NativeHandleGuard.Owner {
         return this.unsafeHandle;
     }
 
-    @Override @SuppressWarnings("deprecation")
+    @Override
+    @SuppressWarnings("deprecation")
     public void finalize() {
         Native.freeGraphState(this.unsafeHandle);
     }

--- a/java/lib/src/test/java/io/amplica/graphsdk/LibraryTest.java
+++ b/java/lib/src/test/java/io/amplica/graphsdk/LibraryTest.java
@@ -1,12 +1,13 @@
 package io.amplica.graphsdk;
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import io.amplica.graphsdk.Graph;
 import io.amplica.graphsdk.Logger;
 import io.amplica.graphsdk.Native;
-import io.amplica.graphsdk.models.DsnpVersion;
-import io.amplica.graphsdk.models.Environment;
-import io.amplica.graphsdk.models.EnvironmentType;
+import io.amplica.graphsdk.models.*;
 import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -71,36 +72,254 @@ class LibraryTest {
     }
 
     @Test
-    void initiate_main_net_state_should_work() {
-        var env = Environment.newBuilder().setEnvironmentType(EnvironmentType.MainNet).build();
-        var graph = new Graph(env);
+    void initiate_main_net_state_should_work() throws InvalidProtocolBufferException {
+        // act
+        var graph = new Graph(Configuration.getMainNet());
 
+        // assert
         assertNotEquals(0, graph.unsafeNativeHandleWithoutGuard());
         graph.finalize();
     }
 
     @Test
-    void initiate_rococo_state_should_work() {
-        var env = Environment.newBuilder().setEnvironmentType(EnvironmentType.Rococo).build();
-        var graph = new Graph(env);
+    void initiate_rococo_state_should_work() throws InvalidProtocolBufferException {
+        // act
+        var graph = new Graph(Configuration.getRococo());
 
+        // assert
         assertNotEquals(0, graph.unsafeNativeHandleWithoutGuard());
         graph.finalize();
     }
 
     @Test
     void initiate_dev_state_should_work() {
-        var config = Environment.newBuilder().getConfigBuilder()
+        // arrange
+        var config = new Configuration(Environment.newBuilder().getConfigBuilder()
                 .addDsnpVersions(DsnpVersion.Version1_0)
                 .setMaxPageId(10)
-                .build();
-        var env = Environment.newBuilder().setEnvironmentType(EnvironmentType.Dev)
-                .setConfig(config)
-                .build();
-        var graph = new Graph(env);
+                .build()
+        );
 
+        // act
+        var graph = new Graph(config);
+
+        // assert
         assertNotEquals(0, graph.unsafeNativeHandleWithoutGuard());
         graph.finalize();
+    }
+
+    @Test
+    void graph_get_user_length_should_work() throws Exception {
+        // arrange
+        var graph = new Graph(Configuration.getMainNet());
+
+        // act
+        var length = graph.getUsersLength();
+
+        // assert
+        assertEquals(0, length);
+        assertNotEquals(0, graph.unsafeNativeHandleWithoutGuard());
+    }
+
+    @Test
+    void graph_containsUserGraph_should_work() throws Exception {
+        // arrange
+        var graph = new Graph(Configuration.getMainNet());
+
+        // act
+        var exists = graph.containsUserGraph(1);
+
+        // assert
+        assertFalse(exists);
+        assertNotEquals(0, graph.unsafeNativeHandleWithoutGuard());
+    }
+
+    @Test
+    void graph_applyActions_addingConnection_should_work() throws Exception {
+        // arrange
+        var ownerUserId = 1;
+        var schemaId = 1;
+        var connectionUserId = 1000;
+        var actions = Actions.newBuilder().addActions(
+                Actions.Action.newBuilder().setConnectAction(
+                        Actions.Action.ConnectAction.newBuilder()
+                                .setOwnerDsnpUserId(ownerUserId)
+                                .setConnection(
+                                        Connection.newBuilder().setDsnpUserId(connectionUserId).setSchemaId(schemaId).build()
+                                ).build())
+        ).build();
+        var graph = new Graph(Configuration.getMainNet());
+
+        // act
+        graph.applyActions(actions);
+        var connections = graph.getConnections(ownerUserId, ConnectionType.FollowPublic, true);
+        var updates = graph.exportUpdates();
+
+        // assert
+        assertEquals(1, connections.size());
+        assertEquals(connectionUserId, connections.get(0).getUserId());
+        assertTrue(connections.get(0).getSince() > 0);
+
+        assertEquals(1, updates.size());
+        assertTrue(updates.get(0).hasPersist());
+        assertEquals(updates.get(0).getPersist().getPageId(), 0);
+        assertEquals(updates.get(0).getPersist().getSchemaId(), schemaId);
+        assertEquals(updates.get(0).getPersist().getOwnerDsnpUserId(), ownerUserId);
+        assertEquals(updates.get(0).getPersist().getPrevHash(), 0);
+
+        assertNotEquals(0, graph.unsafeNativeHandleWithoutGuard());
+    }
+
+    @Test
+    void graph_applyActions_addingKey_should_work() throws Exception {
+        // arrange
+        var ownerUserId = 1;
+        var publicKey = "0fea2cafabdc83752be36fa5349640da2c828add0a290df13cd2d8173eb2496f";
+        var actions = Actions.newBuilder().addActions(
+                Actions.Action.newBuilder().setAddKeyAction(
+                        Actions.Action.AddGraphKey.newBuilder()
+                                .setOwnerDsnpUserId(ownerUserId)
+                                .setNewPublicKey(ByteString.fromHex(publicKey))
+                                .build())
+        ).build();
+        var graph = new Graph(Configuration.getMainNet());
+
+        // act
+        graph.applyActions(actions);
+        var updates = graph.exportUpdates();
+
+        // assert
+        assertEquals(1, updates.size());
+        assertTrue(updates.get(0).hasAddKey());
+        assertEquals(updates.get(0).getAddKey().getPrevHash(), 0);
+        assertEquals(updates.get(0).getAddKey().getOwnerDsnpUserId(), ownerUserId);
+        assertTrue(updates.get(0).getAddKey().getPayload().size() > 0);
+        assertNotEquals(0, graph.unsafeNativeHandleWithoutGuard());
+    }
+
+    @Test
+    void graph_removeUserGraph_should_work() throws Exception {
+        // arrange
+        var ownerUserId = 1;
+        var schemaId = 1;
+        var connectionUserId = 1000;
+        var actions = Actions.newBuilder().addActions(
+                Actions.Action.newBuilder().setConnectAction(
+                        Actions.Action.ConnectAction.newBuilder()
+                                .setOwnerDsnpUserId(ownerUserId)
+                                .setConnection(
+                                        Connection.newBuilder().setDsnpUserId(connectionUserId).setSchemaId(schemaId).build()
+                                ).build())
+        ).build();
+        var graph = new Graph(Configuration.getMainNet());
+        graph.applyActions(actions);
+
+        // act
+        graph.removeUserGraph(ownerUserId);
+
+        // assert
+        var exists = graph.containsUserGraph(ownerUserId);
+        assertFalse(exists);
+        assertNotEquals(0, graph.unsafeNativeHandleWithoutGuard());
+    }
+
+    @Test
+    void graph_importUserData_should_work() throws Exception {
+        // arrange
+        var ownerUserId = 20;
+        var pageId = 5;
+        var schemaId = 1;
+        var contentHash = 1000;
+        var publicKey = ByteString.fromHex("0fea2cafabdc83752be36fa5349640da2c828add0a290df13cd2d8173eb2496f");
+        var bundles = ImportBundles.newBuilder()
+                .addBundles(
+                        ImportBundles.ImportBundle.newBuilder()
+                                .setDsnpUserId(ownerUserId)
+                                .setSchemaId(schemaId)
+                                .setDsnpKeys(DsnpKeys.newBuilder()
+                                        .setDsnpUserId(ownerUserId)
+                                        .setKeysHash(0)
+                                        .addKeys(KeyData.newBuilder().setIndex(0).setContent(ByteString.copyFrom(new byte[]{64, 15, -22, 44, -81, -85, -36, -125, 117, 43, -29, 111, -91, 52, -106, 64, -38, 44, -126, -118, -35, 10, 41, 13, -15, 60, -46, -40, 23, 62, -78, 73, 111})).build())
+                                        .build())
+                                .addPages(
+                                        PageData.newBuilder()
+                                                .setPageId(pageId)
+                                                .setContentHash(contentHash)
+                                                .setContent(ByteString.copyFrom(new byte[]{20, 99, -70, -64, -33, 118, -13, 44, 35, 3, 0}))
+                                                .build())
+                                .build()
+                ).build();
+        var graph = new Graph(Configuration.getMainNet());
+
+        // act
+        graph.importUserData(bundles);
+        var keys = graph.getPublicKeys(ownerUserId);
+
+        // assert
+        var exists = graph.containsUserGraph(ownerUserId);
+        assertTrue(exists);
+
+        var connections = graph.getConnections(ownerUserId, ConnectionType.FollowPublic, false);
+        assertTrue(connections.size() > 0);
+
+        assertEquals(1, keys.size());
+        assertEquals(publicKey, keys.get(0).getKey());
+        assertEquals(0, keys.get(0).getKeyId());
+    }
+
+    @Test
+    void graph_usersWithoutImportedKeys_should_work() throws Exception {
+        // arrange
+        var graph = new Graph(Configuration.getMainNet());
+
+        // act
+        var users = graph.getUsersWithoutImportedKeys();
+
+        // assert
+        assertEquals(0, users.size());
+        assertNotEquals(0, graph.unsafeNativeHandleWithoutGuard());
+    }
+
+    @Test
+    void graph_forceCalculateGraph_should_work() throws Exception {
+        // arrange
+        var ownerUserId = 20;
+        var pageId = 5;
+        var schemaId = 1;
+        var contentHash = 1000;
+        var bundles = ImportBundles.newBuilder()
+                .addBundles(
+                        ImportBundles.ImportBundle.newBuilder()
+                                .setDsnpUserId(ownerUserId)
+                                .setSchemaId(schemaId)
+                                .setDsnpKeys(DsnpKeys.newBuilder()
+                                        .setDsnpUserId(ownerUserId)
+                                        .setKeysHash(0)
+                                        .build())
+                                .addPages(
+                                        PageData.newBuilder()
+                                                .setPageId(pageId)
+                                                .setContentHash(contentHash)
+                                                .setContent(ByteString.copyFrom(new byte[]{20, 99, -70, -64, -33, 118, -13, 44, 35, 3, 0}))
+                                                .build())
+                                .build()
+                ).build();
+        var graph = new Graph(Configuration.getMainNet());
+        graph.importUserData(bundles);
+
+        // act
+        var updates = graph.forceRecalculateGraph(ownerUserId);
+
+        // assert
+        var exists = graph.containsUserGraph(ownerUserId);
+        assertTrue(exists);
+
+        assertEquals(1, updates.size());
+        assertTrue(updates.get(0).hasPersist());
+        assertEquals(updates.get(0).getPersist().getPageId(), pageId);
+        assertEquals(updates.get(0).getPersist().getSchemaId(), schemaId);
+        assertEquals(updates.get(0).getPersist().getOwnerDsnpUserId(), ownerUserId);
+        assertEquals(updates.get(0).getPersist().getPrevHash(), contentHash);
     }
 
     @Test


### PR DESCRIPTION
# Goal
The goal of this PR is implemented rest of JNI apis

Closes #83 

# Discussion
- implements mapping between Jni, Proto and Rust types
- Some minor cleanup in Java side for better usability
- Merging this would feature complete the SDK but there are some leftovers like integrating exception handling in JNI and ...
- Memory allocation and removal seems to be working as expected but will need to do more memory specific testing in future to make sure
# Checklist
- [x] All apis are tested and works as expected. Only `oneSidedFriendship` is not tested since it takes more time to setup the test and will be done in future PR (not a blocker to close this)
