### PR TITLE
new api to deserialize dsnp keys

### DIFF
--- a/bridge/ffi/src/c_example/main.c
+++ b/bridge/ffi/src/c_example/main.c
@@ -78,6 +78,28 @@ int test_initialize_and_clear_states() {
     DsnpPublicKeys publickeys = *(publickeysresult.result);
     ASSERT(publickeys.keys_len == 0, "Failed to get dsnp public keys");
 
+    DsnpKeys keys;
+    // Set the values of the keys struct
+    // ...
+    KeyData keydata;
+    // Set the values of the keydata struct
+    // ...
+    keydata.index = 0;
+    keydata.content = NULL;
+    keydata.content_len = 0;
+
+    keys.dsnp_user_id = userid;
+    keys.keys = &keydata;
+    keys.keys_len = 1;
+    keys.keys_hash = 10;
+    DsnpGraphPublicKeysResult_Error deserializepublickeysresult = graph_deserialize_dsnp_keys(&keys);
+    ASSERT(deserializepublickeysresult.error != NULL, "Expected error to deserialize public keys");
+    errormessage = dsnp_graph_error_message(deserializepublickeysresult.error);
+    ASSERT(errormessage != NULL, "Failed to get error message");
+    errorcode = dsnp_graph_error_code(deserializepublickeysresult.error);
+    free_dsnp_graph_error(deserializepublickeysresult.error);
+    free_dsnp_graph_error_message(errormessage);
+
     free_graph_state(graphstate);
 
     return 0;

--- a/bridge/ffi/src/c_example/main.c
+++ b/bridge/ffi/src/c_example/main.c
@@ -63,7 +63,7 @@ int test_initialize_and_clear_states() {
     DsnpGraphConnectionsWithoutKeysResult_Error connectionswithoutkeysresult = graph_get_connections_without_keys(graphstate);
     ASSERT(connectionswithoutkeysresult.error == NULL, "Failed to get connections without keys");
     GraphConnectionsWithoutKeys connectionswithoutkeys = *(connectionswithoutkeysresult.result);
-    ASSERT(connectionswithoutkeys.connections_len == 0, "Failed to get connections without keys");
+    ASSERT(connectionswithoutkeys.connections != NULL, "Expected zero length");
 
     DsnpGraphConnectionsResult_Error onesidedconnectionsresult = graph_get_one_sided_private_friendship_connections(graphstate, &userid);
     ASSERT(onesidedconnectionsresult.error != NULL, "Expected error to get one sided private friendship connections");

--- a/bridge/ffi/src/utils.rs
+++ b/bridge/ffi/src/utils.rs
@@ -111,7 +111,7 @@ fn key_data_from_ffi(key_data: &KeyData) -> dsnp_graph_core::dsnp::api_types::Ke
 	dsnp_graph_core::dsnp::api_types::KeyData { index: key_data.index, content: content.to_vec() }
 }
 
-fn dsnp_keys_from_ffi(dsnp_keys: &DsnpKeys) -> dsnp_graph_core::dsnp::api_types::DsnpKeys {
+pub fn dsnp_keys_from_ffi(dsnp_keys: &DsnpKeys) -> dsnp_graph_core::dsnp::api_types::DsnpKeys {
 	let keys = unsafe { std::slice::from_raw_parts(dsnp_keys.keys, dsnp_keys.keys_len) };
 	let key_data = keys.iter().map(|key| key_data_from_ffi(key)).collect();
 

--- a/bridge/jni/src/mappings.rs
+++ b/bridge/jni/src/mappings.rs
@@ -97,6 +97,16 @@ pub fn map_to_imports<'local>(
 	Ok(result)
 }
 
+pub fn map_to_dsnp_keys<'local>(
+	env: &JNIEnv<'local>,
+	dsnp_keys: &JByteArray,
+) -> SdkJniResult<RustDsnpKeys> {
+	let bytes = env.convert_byte_array(dsnp_keys).map_err(|e| SdkJniError::from(e))?;
+	let dsnp_keys_proto =
+		proto_input::DsnpKeys::parse_from_bytes(&bytes).map_err(|e| SdkJniError::from(e))?;
+	map_dsnp_keys_to_rust(&dsnp_keys_proto)
+}
+
 pub fn serialize_public_keys<'local>(
 	env: &JNIEnv<'local>,
 	public_keys: &[RustDsnpPublicKey],

--- a/java/lib/src/main/java/io/amplica/graphsdk/Graph.java
+++ b/java/lib/src/main/java/io/amplica/graphsdk/Graph.java
@@ -93,6 +93,11 @@ public class Graph implements NativeHandleGuard.Owner {
         }
     }
 
+    public static List<DsnpPublicKeys.DsnpPublicKey> deserializeDsnpKeys(DsnpKeys keys) throws BaseGraphSdkException, InvalidProtocolBufferException {
+        var raw = Native.deserializeDsnpKeys(keys.toByteArray());
+        return DsnpPublicKeys.parseFrom(raw).getPublicKeyList();
+    }
+
     @Override
     public long unsafeNativeHandleWithoutGuard() {
         return this.unsafeHandle;

--- a/java/lib/src/main/java/io/amplica/graphsdk/Native.java
+++ b/java/lib/src/main/java/io/amplica/graphsdk/Native.java
@@ -93,4 +93,6 @@ public final class Native {
     public static native byte[] getOneSidedPrivateFriendshipConnections(long stateHandle, long dsnpUserId);
 
     public static native byte[] getPublicKeys(long stateHandle, long dsnpUserId);
+
+    public static native byte[] deserializeDsnpKeys(byte[] dsnpKeys);
 }

--- a/java/lib/src/test/java/io/amplica/graphsdk/LibraryTest.java
+++ b/java/lib/src/test/java/io/amplica/graphsdk/LibraryTest.java
@@ -394,6 +394,27 @@ class LibraryTest {
     }
 
     @Test
+    void Graph_deserializeDsnpKeys_should_work() throws Exception {
+        // arrange
+        var ownerUserId = 20;
+        var publicKey = ByteString.fromHex("0fea2cafabdc83752be36fa5349640da2c828add0a290df13cd2d8173eb2496f");
+        var index = 4;
+        var dsnpKeys = DsnpKeys.newBuilder()
+                .setDsnpUserId(ownerUserId)
+                .setKeysHash(1)
+                .addKeys(KeyData.newBuilder().setIndex(index).setContent(ByteString.copyFrom(new byte[]{64, 15, -22, 44, -81, -85, -36, -125, 117, 43, -29, 111, -91, 52, -106, 64, -38, 44, -126, -118, -35, 10, 41, 13, -15, 60, -46, -40, 23, 62, -78, 73, 111})).build())
+                .build();
+
+        // act
+        var keys = Graph.deserializeDsnpKeys(dsnpKeys);
+
+        // assert
+        assertEquals(1, keys.size());
+        assertEquals(publicKey, keys.get(0).getKey());
+        assertEquals(index, keys.get(0).getKeyId());
+    }
+
+    @Test
     void logger_double_initialize_should_fail() {
         Logger.initialize();
         assertEquals(true, testLogsForPattern(Level.WARN, "Duplicate logger initialization ignored"));


### PR DESCRIPTION
# Goal
The goal of this PR is to create a new api that without changing the state will deserialize dsnp keys.

Closes #98 
# Discussion
- FFI tests are not added due to issues related to lib-sodium dependency in C any help would be appreciated @saraswatpuneet

# Checklist
- [x] Integration Tests added
- [x] JNI Tests added
- [x] FFI Tests 
