### PR TITLE
edge-case: handles reimports after updates

### DIFF
--- a/config/src/errors.rs
+++ b/config/src/errors.rs
@@ -63,12 +63,12 @@ pub enum DsnpGraphError {
 	FailedToRetrieveGraphPage,
 
 	/// Failed to acquire read lock on state manager
-	#[error("Failed to acquire read lock on state manager")]
-	FailedtoReadLockStateManager,
+	#[error("Failed to acquire read lock on {0}")]
+	FailedtoReadLock(String),
 
 	/// Failed to acquire write lock on state manager
-	#[error("Failed to acquire write lock on state manager")]
-	FailedtoWriteLockStateManager,
+	#[error("Failed to acquire write lock on {0}")]
+	FailedtoWriteLock(String),
 
 	/// FFI error
 	#[error("FFI error: {0}")]
@@ -198,8 +198,8 @@ impl DsnpGraphError {
 			DsnpGraphError::EventExists => 11,
 			DsnpGraphError::EncryptionError(_) => 12,
 			DsnpGraphError::FailedToRetrieveGraphPage => 13,
-			DsnpGraphError::FailedtoReadLockStateManager => 14,
-			DsnpGraphError::FailedtoWriteLockStateManager => 15,
+			DsnpGraphError::FailedtoReadLock(_) => 14,
+			DsnpGraphError::FailedtoWriteLock(_) => 15,
 			DsnpGraphError::GraphIsFull => 16,
 			DsnpGraphError::GraphStateIsFull => 17,
 			DsnpGraphError::InvalidDsnpUserId(_) => 18,

--- a/core/src/graph/shared_state_manager.rs
+++ b/core/src/graph/shared_state_manager.rs
@@ -13,6 +13,9 @@ use crate::{
 use dsnp_graph_config::errors::{DsnpGraphError, DsnpGraphResult};
 use std::{borrow::Borrow, collections::HashSet};
 
+/// Constant used in errors
+pub const SHARED_STATE_MANAGER: &str = "SharedStateManager";
+
 /// A trait that defines all the functionality that a pri manager should implement.
 pub trait PriProvider {
 	/// imports pri for a user and replaces the older ones if exists
@@ -125,7 +128,7 @@ impl PublicKeyProvider for SharedStateManager {
 			let mut k =
 				Frequency::read_public_key(&key.content).map_err(|e| DsnpGraphError::from(e))?;
 
-			// make sure it can deserializes correctly
+			// make sure it can deserialize correctly
 			let _: PublicKeyType = k.borrow().try_into()?;
 			// key id is the itemized index of the key stored in Frequency
 			k.key_id = Some(key.index.into());

--- a/core/src/graph/user.rs
+++ b/core/src/graph/user.rs
@@ -104,6 +104,16 @@ impl UserGraph {
 		&mut self.update_tracker
 	}
 
+	/// Getter for UpdateTracker
+	pub fn sync_updates(&mut self, schema_id: SchemaId) {
+		let non_pending_connections: HashSet<DsnpUserId> = self
+			.get_all_connections_of(schema_id, false)
+			.iter()
+			.map(|c| c.user_id)
+			.collect();
+		self.update_tracker.sync_updates(schema_id, &non_pending_connections);
+	}
+
 	/// Getter for the user's graph for the specified ConnectionType
 	pub fn graph(&self, schema_id: &SchemaId) -> Option<&Graph> {
 		self.graphs.get(schema_id)


### PR DESCRIPTION
# Goal
The goal of this PR is to handle the edge case which re-imports of user data might happen after adding some updates. This would make sure that those updates are compatible with newly reimported user data and remove the non compatible ones.

Closes #49

# Notes
- Handles some of the unwraps around locks that were lingering around. We still have some unwraps in methods that do not return Result types but to handle them we will need to change the method signature which is  bigger than the scope of this PR.

# Checklist
- [x] Tests added
