### PR TITLE
changed protobuf to be self-contained dependency

### DIFF
--- a/java/lib/build.gradle.kts
+++ b/java/lib/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     testImplementation("io.github.hakky54:logcaptor:2.9.0")
 
     implementation("org.slf4j:slf4j-api:2.0.7")
-    implementation("com.google.protobuf:protobuf-java:3.23.0")
+    api("com.google.protobuf:protobuf-java:3.23.0")
 }
 
 java {


### PR DESCRIPTION
# Goal
The goal of this PR is to make sure JNI library has protobuf dependency in a self contained way and we don't need to include that dependency in the upper library which is using the graphsdk

Closes #125 