### PR TITLE
Increase graph limit to 10k

### DIFF
--- a/bridge/ffi/src/c_example/main.c
+++ b/bridge/ffi/src/c_example/main.c
@@ -132,7 +132,7 @@ int test_state_capacity() {
 }
 
 int test_initialize_state_with_larger_capacity() {
-    size_t capacity = 10000;
+    size_t capacity = 100000;
     Environment env;
     env.tag = Mainnet;
     GraphState* state = NULL;

--- a/bridge/node/js/graph.test.ts
+++ b/bridge/node/js/graph.test.ts
@@ -46,7 +46,7 @@ test('getGraphConfig with Mainnet environment should return the graph config', a
     const graph = new Graph(environment);
     const config = await graph.getGraphConfig(environment);
     expect(config).toBeDefined();
-    expect(config.sdkMaxUsersGraphSize).toEqual(1000);
+    expect(config.sdkMaxUsersGraphSize).toEqual(10000);
     const schema_id = await graph.getSchemaIdFromConfig(environment, ConnectionType.Follow, PrivacyType.Public);
     expect(schema_id).toEqual(1);
     await graph.freeGraphState();
@@ -57,7 +57,7 @@ test('getGraphConfig with Rococo environment should return the graph config', as
     const graph = new Graph(environment);
     const config = await graph.getGraphConfig(environment);
     expect(config).toBeDefined();
-    expect(config.sdkMaxUsersGraphSize).toEqual(1000);
+    expect(config.sdkMaxUsersGraphSize).toEqual(10000);
     await graph.freeGraphState();
 });
 
@@ -223,7 +223,7 @@ test('applyActions with few actions should pass through on initialized graph', a
     const exported = await graph.exportUpdates();
     expect(exported).toBeDefined();
     expect(exported.length).toEqual(1);
-    
+
     await graph.freeGraphState();
 });
 
@@ -294,7 +294,7 @@ test('deserializeDsnpKeys with empty keys should return empty array', async () =
     const graph = new Graph(environment);
     const handle = graph.getGraphHandle();
     expect(handle).toBeDefined();
-    const keys = {          
+    const keys = {
         dsnpUserId: "2",
         keysHash: 100,
         keys: [],
@@ -324,7 +324,7 @@ test('Create and export a new graph', async () => {
             keys: [],
         } as DsnpKeys,
     } as ConnectAction;
-    
+
     let actions = [] as Action[];
     actions.push(connect_action);
     let applied = await graph.applyActions(actions);

--- a/config/resources/configs/frequency-rococo.json
+++ b/config/resources/configs/frequency-rococo.json
@@ -1,5 +1,5 @@
 {
-  "sdkMaxUsersGraphSize" : 1000,
+  "sdkMaxUsersGraphSize" : 10000,
   "sdkMaxStaleFriendshipDays" : 90,
   "maxGraphPageSizeBytes": 1024,
   "maxPageId": 16,

--- a/config/resources/configs/frequency.json
+++ b/config/resources/configs/frequency.json
@@ -1,5 +1,5 @@
 {
-  "sdkMaxUsersGraphSize" : 1000,
+  "sdkMaxUsersGraphSize" : 10000,
   "sdkMaxStaleFriendshipDays" : 90,
   "maxGraphPageSizeBytes": 1024,
   "maxPageId": 16,

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -245,7 +245,7 @@ impl Config {
 #[cfg(test)]
 mod config_tests {
 	use super::*;
-	use pretty_assertions::{assert_eq, assert_ne};
+	use pretty_assertions::assert_eq;
 	use test_log::test;
 
 	#[test]

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -243,8 +243,9 @@ impl Config {
 }
 
 #[cfg(test)]
-mod test {
+mod config_tests {
 	use super::*;
+	use pretty_assertions::{assert_eq, assert_ne};
 	use test_log::test;
 
 	#[test]
@@ -267,7 +268,7 @@ mod test {
 	#[test]
 	fn config_import_success() -> Result<(), serde_json::Error> {
 		let expected_config = Config {
-			sdk_max_users_graph_size: 1000,
+			sdk_max_users_graph_size: 10000,
 			sdk_max_stale_friendship_days: 90,
 			max_graph_page_size_bytes: 1024,
 			max_page_id: 16,

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -57,7 +57,7 @@ mod integration_tests {
 	#[test]
 	fn state_with_capacity_of_higher_than_env_should_return_smaller_capacity() {
 		// arrange
-		let capacity: usize = 10000;
+		let capacity: usize = 11000;
 		let env = Environment::Mainnet;
 
 		// act


### PR DESCRIPTION
# Goal
The goal of this PR is to increase the number of user graphs that can be held in a single `GraphState` in order to support holding all of at least one user's connections in one `GraphState`.

Closes #134 

# Checklist
- [x] Tests updated
