### PR TITLE
update api for  sending dsnpUserid as string

### DIFF
--- a/bridge/node/js/graph.ts
+++ b/bridge/node/js/graph.ts
@@ -66,7 +66,7 @@ export class Graph {
         return graphsdkModule.forceCalculateGraphs(this.handle, dsnpUserId);
     }
 
-    getConnectionsWithoutKeys(): Promise<number[]> {
+    getConnectionsWithoutKeys(): Promise<string[]> {
         return graphsdkModule.getConnectionsWithoutKeys(this.handle);
     }
 

--- a/bridge/node/js/index.ts
+++ b/bridge/node/js/index.ts
@@ -28,7 +28,7 @@ export interface Native {
     exportUpdates(handle: number): Promise<Update[]>;
     getConnectionsForUserGraph(handle: number, dsnpUserId: string, schemaId: number, includePending: boolean):Promise<DsnpGraphEdge[]>;
     forceCalculateGraphs(handle: number, dsnpUserId: string): Promise<Update[]>;
-    getConnectionsWithoutKeys(handle: number): Promise<number[]>;
+    getConnectionsWithoutKeys(handle: number): Promise<string[]>;
     getOneSidedPrivateFriendshipConnections(handle: number, dsnpUserId: string): Promise<DsnpGraphEdge[]>;
     getPublicKeys(handle: number, dsnpUserId: string): Promise<DsnpPublicKey[]>;
     deserializeDsnpKeys(keys: DsnpKeys): Promise<DsnpPublicKey[]>;

--- a/bridge/node/src/api.rs
+++ b/bridge/node/src/api.rs
@@ -463,8 +463,8 @@ pub fn get_connections_without_keys(mut cx: FunctionContext) -> JsResult<JsArray
 		Ok(connections) => {
 			let connections_js = cx.empty_array();
 			for (i, connection) in connections.iter().enumerate() {
-				let dsnp_user_id = cx.number(*connection as f64);
-				connections_js.set(&mut cx, i as u32, dsnp_user_id)?;
+				let connection_js_string: Handle<'_, JsString> = cx.string(connection.to_string());
+				connections_js.set(&mut cx, i as u32, connection_js_string)?;
 			}
 			Ok(connections_js)
 		},


### PR DESCRIPTION
# Goal
The goal of this PR is to update node api to return list of dsnp id as string owing to node constraints with u64
