### PR TITLE
dry run PR publish

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - main
+  push :
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -290,7 +290,14 @@ jobs:
         run: npm run native:build-release && cp README.md dist/README.md
       - name: Publish NPM Package
         working-directory: bridge/node
+        if: github.ref == 'refs/heads/main'
         run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      - name: Dry run NPM Package
+        working-directory: bridge/node
+        if: github.ref != 'refs/heads/main'
+        run: npm publish --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 

--- a/bridge/node/package.json
+++ b/bridge/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsnp/graph-sdk",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "Amplica Labs",
   "license": "Apache-2.0",
   "description": "dsnp-graph-sdk-node",


### PR DESCRIPTION
# Goal
The goal of this PR is to not publish npm graphsdk package for PRs, to verify on PR a `--dry-run` is performed on package to be published 

Closes #147 
