### PR TITLE
added getter for graphPublicKeySchemaId in jvm

### DIFF
--- a/java/lib/src/main/java/io/amplica/graphsdk/Configuration.java
+++ b/java/lib/src/main/java/io/amplica/graphsdk/Configuration.java
@@ -40,6 +40,10 @@ public class Configuration {
         return this.schemaIdMap.get(connectionType);
     }
 
+    public int getGraphPublicKeySchemaId() {
+        return this.inner.getGraphPublicKeySchemaId();
+    }
+
     public Environment getEnvironment() {
         return this.environment;
     }

--- a/java/lib/src/test/java/io/amplica/graphsdk/LibraryTest.java
+++ b/java/lib/src/test/java/io/amplica/graphsdk/LibraryTest.java
@@ -87,6 +87,16 @@ class LibraryTest {
     }
 
     @Test
+    void graph_schema_id_should_return_correctly() throws Exception {
+        // act
+        var configuration = Configuration.getMainNet();
+        var keySchemaId = configuration.getGraphPublicKeySchemaId();
+
+        // assert
+        assertNotEquals(0, keySchemaId);
+    }
+
+    @Test
     void initiate_dev_state_should_work() throws Exception {
         // arrange
         var config = new Configuration(Environment.newBuilder().getConfigBuilder()


### PR DESCRIPTION
# Goal
The goal of this PR is implement a getter for graph public keys schema id which is useful in custodial wallet and other projects.

Closes #158 

