### PR TITLE
jvm publish 0.0.1 for custodial wallet

### DIFF
--- a/java/lib/build.gradle.kts
+++ b/java/lib/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "io.amplica.graphsdk"
-version = "0.0.1-SNAPSHOT"
+version = "0.0.1"
 java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {


### PR DESCRIPTION
# Goal
The goal of this PR is publish a non-snapshot jvm package so we can use in custodial wallet

