### PR TITLE
When setting import bundles, allow 0 schemaId  for empty pages

### DIFF
--- a/bridge/node/js/graph.test.ts
+++ b/bridge/node/js/graph.test.ts
@@ -483,4 +483,34 @@ describe("Graph tests", () => {
     expect(keyPair.secretKey).toBeDefined();
     expect(keyPair.keyType).toEqual(GraphKeyType.X25519);
   });
+
+  test("Import bundle without schema id and empty pages should import keys", async () => {
+    const dsnpUserId = "1";
+    const keyPair = Graph.generateKeyPair(GraphKeyType.X25519);
+    const keyPairs = [keyPair];
+    const dsnpKeys = {
+      dsnpUserId,
+      keysHash: 100,
+      keys: [
+        {
+          index: 0,
+          content: keyPair.publicKey,
+        },
+      ] as KeyData[],
+    } as DsnpKeys;
+
+    const importBundle: ImportBundle = {
+      dsnpUserId,
+      keyPairs,
+      dsnpKeys,
+      pages: [],
+    };
+
+    const imported = graph.importUserData([importBundle]);
+    expect(imported).toEqual(true);
+
+    const exported = graph.exportUpdates();
+    expect(exported).toBeDefined();
+    expect(exported.length).toEqual(1);
+  });
 });

--- a/bridge/node/js/models/import_bundle.ts
+++ b/bridge/node/js/models/import_bundle.ts
@@ -27,8 +27,8 @@ export interface PageData {
 
 export interface ImportBundle {
   dsnpUserId: string;
-  schemaId: number;
-  keyPairs: GraphKeyPair[];
+  schemaId?: number;
+  keyPairs?: GraphKeyPair[];
   dsnpKeys?: DsnpKeys;
-  pages: PageData[];
+  pages?: PageData[];
 }

--- a/core/src/api/api_types.rs
+++ b/core/src/api/api_types.rs
@@ -143,7 +143,7 @@ impl InputValidation for ImportBundle {
 		if self.dsnp_user_id == 0 {
 			return DsnpGraphResult::Err(InvalidDsnpUserId(self.dsnp_user_id))
 		}
-		if self.schema_id == 0 {
+		if self.schema_id == 0 && self.pages.len() > 0 {
 			return DsnpGraphResult::Err(InvalidSchemaId(self.schema_id))
 		}
 


### PR DESCRIPTION
# Goal
The goal of this PR is to by pass validation of schemaId in a bundle if number of pages in a bundle == 0, this will make it easy for consume to simply add `DsnpKeys` and `GraphKeyPairs` to an empty bundle

Closes #168 


# Checklist
- [ ] Tests added
