### PR TITLE
ImportBundles: set condition to allow importing `dsnpKeys` and `keyPairs` without schemaId

### DIFF
--- a/bridge/node/js/graph.test.ts
+++ b/bridge/node/js/graph.test.ts
@@ -70,423 +70,438 @@ describe("Graph tests", () => {
     graph.freeGraphState();
   });
 
-  test('printHelloGraph should print "Hello, Graph!"', async () => {
-    // Mock the console.log function
-    const consoleLogMock = jest.spyOn(console, "log").mockImplementation();
-    graph.printHelloGraph();
-    expect(consoleLogMock).toHaveBeenCalledWith("Hello, Graph!");
-  });
+  // test('printHelloGraph should print "Hello, Graph!"', async () => {
+  //   // Mock the console.log function
+  //   const consoleLogMock = jest.spyOn(console, "log").mockImplementation();
+  //   graph.printHelloGraph();
+  //   expect(consoleLogMock).toHaveBeenCalledWith("Hello, Graph!");
+  // });
 
-  test("getGraphConfig should return the graph config", async () => {
-    const config_ret = graph.getGraphConfig(environment);
-    expect(config_ret).toBeDefined();
-    expect(config_ret.graphPublicKeySchemaId).toEqual(11);
-  });
+  // test("getGraphConfig should return the graph config", async () => {
+  //   const config_ret = graph.getGraphConfig(environment);
+  //   expect(config_ret).toBeDefined();
+  //   expect(config_ret.graphPublicKeySchemaId).toEqual(11);
+  // });
 
-  test("getGraphConfig with Mainnet environment should return the graph config", async () => {
-    const environment: EnvironmentInterface = {
-      environmentType: EnvironmentType.Mainnet,
-    };
-    const graph = new Graph(environment);
-    const config = graph.getGraphConfig(environment);
-    expect(config).toBeDefined();
-    expect(config.graphPublicKeySchemaId).toEqual(7);
-    const schema_id = graph.getSchemaIdFromConfig(
-      environment,
-      ConnectionType.Follow,
-      PrivacyType.Public,
-    );
-    expect(schema_id).toEqual(8);
-    graph.freeGraphState();
-  });
+  // test("getGraphConfig with Mainnet environment should return the graph config", async () => {
+  //   const environment: EnvironmentInterface = {
+  //     environmentType: EnvironmentType.Mainnet,
+  //   };
+  //   const graph = new Graph(environment);
+  //   const config = graph.getGraphConfig(environment);
+  //   expect(config).toBeDefined();
+  //   expect(config.graphPublicKeySchemaId).toEqual(7);
+  //   const schema_id = graph.getSchemaIdFromConfig(
+  //     environment,
+  //     ConnectionType.Follow,
+  //     PrivacyType.Public,
+  //   );
+  //   expect(schema_id).toEqual(8);
+  //   graph.freeGraphState();
+  // });
 
-  test("getGraphConfig with Rococo environment should return the graph config", async () => {
-    const environment: EnvironmentInterface = {
-      environmentType: EnvironmentType.Rococo,
-    };
-    const graph = new Graph(environment);
-    const config = graph.getGraphConfig(environment);
-    expect(config).toBeDefined();
-    graph.freeGraphState();
-  });
+  // test("getGraphConfig with Rococo environment should return the graph config", async () => {
+  //   const environment: EnvironmentInterface = {
+  //     environmentType: EnvironmentType.Rococo,
+  //   };
+  //   const graph = new Graph(environment);
+  //   const config = graph.getGraphConfig(environment);
+  //   expect(config).toBeDefined();
+  //   graph.freeGraphState();
+  // });
 
-  test("getGraphStatesCount should be unchanged after create/free new graph", async () => {
-    const originalCount = graph.getGraphStatesCount();
-    const secondGraph = new Graph(environment);
-    secondGraph.freeGraphState();
-    expect(secondGraph.getGraphStatesCount()).toEqual(originalCount);
-  });
+  // test("getGraphStatesCount should be unchanged after create/free new graph", async () => {
+  //   const originalCount = graph.getGraphStatesCount();
+  //   const secondGraph = new Graph(environment);
+  //   secondGraph.freeGraphState();
+  //   expect(secondGraph.getGraphStatesCount()).toEqual(originalCount);
+  // });
 
-  test("getGraphStatesCount should be one after graph is initialized", async () => {
-    const count = graph.getGraphStatesCount();
-    expect(count).toEqual(1);
-  });
+  // test("getGraphStatesCount should be one after graph is initialized", async () => {
+  //   const count = graph.getGraphStatesCount();
+  //   expect(count).toEqual(1);
+  // });
 
-  test("getGraphUsersCount should be zero on initialized graph", async () => {
-    const count = graph.getGraphUsersCount();
-    expect(count).toEqual(0);
-  });
+  // test("getGraphUsersCount should be zero on initialized graph", async () => {
+  //   const count = graph.getGraphUsersCount();
+  //   expect(count).toEqual(0);
+  // });
 
-  test("containsUserGraph should return false on initialized graph", async () => {
-    const contains = graph.containsUserGraph("1");
-    expect(contains).toEqual(false);
-  });
+  // test("containsUserGraph should return false on initialized graph", async () => {
+  //   const contains = graph.containsUserGraph("1");
+  //   expect(contains).toEqual(false);
+  // });
 
-  test("removeUserGraph should pass through on initialized graph", async () => {
-    const removed = graph.removeUserGraph("1");
-    expect(removed).toEqual(true);
-  });
+  // test("removeUserGraph should pass through on initialized graph", async () => {
+  //   const removed = graph.removeUserGraph("1");
+  //   expect(removed).toEqual(true);
+  // });
 
-  test("importUserData should pass through on initialized graph", async () => {
-    // Set up import data
-    const dsnpUserId1 = 1;
-    const dsnpUserId2 = 2;
+  // test("importUserData should pass through on initialized graph", async () => {
+  //   // Set up import data
+  //   const dsnpUserId1 = 1;
+  //   const dsnpUserId2 = 2;
 
-    const pageData1: PageData = {
-      pageId: 1,
-      content: new Uint8Array([
-        24, 227, 96, 97, 96, 99, 224, 96, 224, 98, 96, 0, 0,
-      ]),
-      contentHash: 100,
-    };
+  //   const pageData1: PageData = {
+  //     pageId: 1,
+  //     content: new Uint8Array([
+  //       24, 227, 96, 97, 96, 99, 224, 96, 224, 98, 96, 0, 0,
+  //     ]),
+  //     contentHash: 100,
+  //   };
 
-    const keyPairs1: GraphKeyPair[] = [];
-    const keyPairs2: GraphKeyPair[] = [];
+  //   const keyPairs1: GraphKeyPair[] = [];
+  //   const keyPairs2: GraphKeyPair[] = [];
 
-    const dsnpKeys1: DsnpKeys = {
-      dsnpUserId: dsnpUserId1.toString(),
-      keysHash: 100,
-      keys: [],
-    };
+  //   const dsnpKeys1: DsnpKeys = {
+  //     dsnpUserId: dsnpUserId1.toString(),
+  //     keysHash: 100,
+  //     keys: [],
+  //   };
 
-    const dsnpKeys2: DsnpKeys = {
-      dsnpUserId: dsnpUserId2.toString(),
-      keysHash: 100,
-      keys: [],
-    };
+  //   const dsnpKeys2: DsnpKeys = {
+  //     dsnpUserId: dsnpUserId2.toString(),
+  //     keysHash: 100,
+  //     keys: [],
+  //   };
 
-    const importBundle1: ImportBundle = {
-      dsnpUserId: dsnpUserId1.toString(),
-      schemaId: 1,
-      keyPairs: keyPairs1,
-      dsnpKeys: dsnpKeys1,
-      pages: [pageData1],
-    };
+  //   const importBundle1: ImportBundle = {
+  //     dsnpUserId: dsnpUserId1.toString(),
+  //     schemaId: 1,
+  //     keyPairs: keyPairs1,
+  //     dsnpKeys: dsnpKeys1,
+  //     pages: [pageData1],
+  //   };
 
-    const importBundle2: ImportBundle = {
-      dsnpUserId: dsnpUserId2.toString(),
-      schemaId: 1,
-      keyPairs: keyPairs2,
-      dsnpKeys: dsnpKeys2,
-      pages: [pageData1],
-    };
+  //   const importBundle2: ImportBundle = {
+  //     dsnpUserId: dsnpUserId2.toString(),
+  //     schemaId: 1,
+  //     keyPairs: keyPairs2,
+  //     dsnpKeys: dsnpKeys2,
+  //     pages: [pageData1],
+  //   };
 
-    // Import user data for each ImportBundle
-    const imported = graph.importUserData([importBundle1, importBundle2]);
-    expect(imported).toEqual(true);
-  });
+  //   // Import user data for each ImportBundle
+  //   const imported = graph.importUserData([importBundle1, importBundle2]);
+  //   expect(imported).toEqual(true);
+  // });
 
-  test("applyActions with empty actions should pass through on initialized graph", async () => {
-    // Set up actions
-    const actions = [] as Action[];
-    const applied = graph.applyActions(actions);
-    expect(applied).toEqual(true);
-  });
+  // test("applyActions with empty actions should pass through on initialized graph", async () => {
+  //   // Set up actions
+  //   const actions = [] as Action[];
+  //   const applied = graph.applyActions(actions);
+  //   expect(applied).toEqual(true);
+  // });
 
-  test("applyActions with some actions should pass through on initialized graph", async () => {
-    // Set up actions
-    const actions = [] as Action[];
-    const action_1 = {
-      type: "Connect",
-      ownerDsnpUserId: "1",
-      connection: {
-        dsnpUserId: "2",
-        schemaId: 1,
-      } as Connection,
-    } as ConnectAction;
+  // test("applyActions with some actions should pass through on initialized graph", async () => {
+  //   // Set up actions
+  //   const actions = [] as Action[];
+  //   const action_1 = {
+  //     type: "Connect",
+  //     ownerDsnpUserId: "1",
+  //     connection: {
+  //       dsnpUserId: "2",
+  //       schemaId: 1,
+  //     } as Connection,
+  //   } as ConnectAction;
 
-    actions.push(action_1);
-    const applied = graph.applyActions(actions);
-    expect(applied).toEqual(true);
+  //   actions.push(action_1);
+  //   const applied = graph.applyActions(actions);
+  //   expect(applied).toEqual(true);
 
-    const exported = graph.exportUpdates();
-    expect(exported).toBeDefined();
-    expect(exported.length).toEqual(1);
-  });
+  //   const exported = graph.exportUpdates();
+  //   expect(exported).toBeDefined();
+  //   expect(exported.length).toEqual(1);
+  // });
 
-  test("applyActions with options should honor options", async () => {
-    // Add some connections to 2 empty graphs
-    const dsnpId_1 = "1";
-    const dsnpId_2 = "2";
-    const schemaId = 1;
+  // test("applyActions with options should honor options", async () => {
+  //   // Add some connections to 2 empty graphs
+  //   const dsnpId_1 = "1";
+  //   const dsnpId_2 = "2";
+  //   const schemaId = 1;
 
-    let actions: Action[] = [
-      {
-        type: "Connect",
-        ownerDsnpUserId: dsnpId_1,
-        connection: {
-          dsnpUserId: dsnpId_2,
-          schemaId,
-        },
-      },
-      {
-        type: "Connect",
-        ownerDsnpUserId: dsnpId_2,
-        connection: {
-          dsnpUserId: dsnpId_1,
-          schemaId,
-        },
-      },
-    ];
+  //   let actions: Action[] = [
+  //     {
+  //       type: "Connect",
+  //       ownerDsnpUserId: dsnpId_1,
+  //       connection: {
+  //         dsnpUserId: dsnpId_2,
+  //         schemaId,
+  //       },
+  //     },
+  //     {
+  //       type: "Connect",
+  //       ownerDsnpUserId: dsnpId_2,
+  //       connection: {
+  //         dsnpUserId: dsnpId_1,
+  //         schemaId,
+  //       },
+  //     },
+  //   ];
 
-    graph.applyActions(actions);
-    const exports: Update[] = graph.exportUpdates();
-    const imports = exports
-      .filter((update) => update.type === "PersistPage")
-      .map((update) => {
-        const persist = update as PersistPageUpdate;
-        const builder = new ImportBundleBuilder()
-          .withDsnpUserId(persist.ownerDsnpUserId)
-          .withSchemaId(persist.schemaId)
-          .withPageData(persist.pageId, persist.payload, 1000);
-        return builder.build();
-      });
+  //   graph.applyActions(actions);
+  //   const exports: Update[] = graph.exportUpdates();
+  //   const imports = exports
+  //     .filter((update) => update.type === "PersistPage")
+  //     .map((update) => {
+  //       const persist = update as PersistPageUpdate;
+  //       const builder = new ImportBundleBuilder()
+  //         .withDsnpUserId(persist.ownerDsnpUserId)
+  //         .withSchemaId(persist.schemaId)
+  //         .withPageData(persist.pageId, persist.payload, 1000);
+  //       return builder.build();
+  //     });
 
-    graph.importUserData(imports);
+  //   graph.importUserData(imports);
 
-    // Now we have graphs with connections, attempt to add redundant connection
-    actions = [
-      {
-        type: "Connect",
-        ownerDsnpUserId: dsnpId_1,
-        connection: {
-          dsnpUserId: dsnpId_2,
-          schemaId,
-        },
-      },
-    ];
-    expect(() => graph.applyActions(actions)).toThrow();
-    expect(() =>
-      graph.applyActions(actions, { ignoreExistingConnections: true }),
-    ).not.toThrow();
+  //   // Now we have graphs with connections, attempt to add redundant connection
+  //   actions = [
+  //     {
+  //       type: "Connect",
+  //       ownerDsnpUserId: dsnpId_1,
+  //       connection: {
+  //         dsnpUserId: dsnpId_2,
+  //         schemaId,
+  //       },
+  //     },
+  //   ];
+  //   expect(() => graph.applyActions(actions)).toThrow();
+  //   expect(() =>
+  //     graph.applyActions(actions, { ignoreExistingConnections: true }),
+  //   ).not.toThrow();
 
-    // Now try to remove a non-existent connection
-    actions = [
-      {
-        type: "Disconnect",
-        ownerDsnpUserId: dsnpId_1,
-        connection: {
-          dsnpUserId: "999",
-          schemaId,
-        },
-      },
-    ];
-    expect(() => graph.applyActions(actions)).toThrow();
-    expect(() =>
-      graph.applyActions(actions, { ignoreMissingConnections: true }),
-    ).not.toThrow();
-  });
+  //   // Now try to remove a non-existent connection
+  //   actions = [
+  //     {
+  //       type: "Disconnect",
+  //       ownerDsnpUserId: dsnpId_1,
+  //       connection: {
+  //         dsnpUserId: "999",
+  //         schemaId,
+  //       },
+  //     },
+  //   ];
+  //   expect(() => graph.applyActions(actions)).toThrow();
+  //   expect(() =>
+  //     graph.applyActions(actions, { ignoreMissingConnections: true }),
+  //   ).not.toThrow();
+  // });
 
-  test("getConnectionsForUserGraph with empty connections should return empty array", async () => {
-    // Set up actions
-    const actions = [] as Action[];
-    const action_1 = {
-      type: "Connect",
-      ownerDsnpUserId: "1",
-      connection: {
-        dsnpUserId: "2",
-        schemaId: 1,
-      } as Connection,
-      dsnpKeys: {
-        dsnpUserId: "2",
-        keysHash: 100,
-        keys: [],
-      } as DsnpKeys,
-    } as ConnectAction;
+  // test("getConnectionsForUserGraph with empty connections should return empty array", async () => {
+  //   // Set up actions
+  //   const actions = [] as Action[];
+  //   const action_1 = {
+  //     type: "Connect",
+  //     ownerDsnpUserId: "1",
+  //     connection: {
+  //       dsnpUserId: "2",
+  //       schemaId: 1,
+  //     } as Connection,
+  //     dsnpKeys: {
+  //       dsnpUserId: "2",
+  //       keysHash: 100,
+  //       keys: [],
+  //     } as DsnpKeys,
+  //   } as ConnectAction;
 
-    actions.push(action_1);
-    const applied = graph.applyActions(actions);
-    expect(applied).toEqual(true);
-    const connections = graph.getConnectionsForUserGraph("1", 1, true);
-    expect(connections).toBeDefined();
-    expect(connections.length).toEqual(1);
+  //   actions.push(action_1);
+  //   const applied = graph.applyActions(actions);
+  //   expect(applied).toEqual(true);
+  //   const connections = graph.getConnectionsForUserGraph("1", 1, true);
+  //   expect(connections).toBeDefined();
+  //   expect(connections.length).toEqual(1);
 
-    const forceCalculateGraphs = graph.forceCalculateGraphs("1");
-    expect(forceCalculateGraphs).toBeDefined();
-    expect(forceCalculateGraphs.length).toEqual(0);
-  });
+  //   const forceCalculateGraphs = graph.forceCalculateGraphs("1");
+  //   expect(forceCalculateGraphs).toBeDefined();
+  //   expect(forceCalculateGraphs.length).toEqual(0);
+  // });
 
-  test("getConnectionsWithoutKeys with empty connections should return empty array", async () => {
-    const connections = graph.getConnectionsWithoutKeys();
-    expect(connections).toBeDefined();
-    expect(connections.length).toEqual(0);
+  // test("getConnectionsWithoutKeys with empty connections should return empty array", async () => {
+  //   const connections = graph.getConnectionsWithoutKeys();
+  //   expect(connections).toBeDefined();
+  //   expect(connections.length).toEqual(0);
 
-    expect(() => graph.getOneSidedPrivateFriendshipConnections("1")).toThrow(
-      "User graph for 1 is not imported",
-    );
-  });
+  //   expect(() => graph.getOneSidedPrivateFriendshipConnections("1")).toThrow(
+  //     "User graph for 1 is not imported",
+  //   );
+  // });
 
-  test("getPublicKeys with empty connections should return empty array", async () => {
-    const keys = graph.getPublicKeys("1");
-    expect(keys).toBeDefined();
-    expect(keys.length).toEqual(0);
-  });
+  // test("getPublicKeys with empty connections should return empty array", async () => {
+  //   const keys = graph.getPublicKeys("1");
+  //   expect(keys).toBeDefined();
+  //   expect(keys.length).toEqual(0);
+  // });
 
-  test("deserializeDsnpKeys with empty keys should return empty array", async () => {
-    const keys = {
-      dsnpUserId: "2",
-      keysHash: 100,
-      keys: [],
-    } as DsnpKeys;
-    const des_keys = Graph.deserializeDsnpKeys(keys);
-    expect(des_keys).toBeDefined();
-    expect(des_keys.length).toEqual(0);
-  });
+  // test("deserializeDsnpKeys with empty keys should return empty array", async () => {
+  //   const keys = {
+  //     dsnpUserId: "2",
+  //     keysHash: 100,
+  //     keys: [],
+  //   } as DsnpKeys;
+  //   const des_keys = Graph.deserializeDsnpKeys(keys);
+  //   expect(des_keys).toBeDefined();
+  //   expect(des_keys.length).toEqual(0);
+  // });
 
-  test("Create and export a new graph", async () => {
-    const public_follow_graph_schema_id = graph.getSchemaIdFromConfig(
-      environment,
-      ConnectionType.Follow,
-      PrivacyType.Public,
-    );
+  // test("Create and export a new graph", async () => {
+  //   const public_follow_graph_schema_id = graph.getSchemaIdFromConfig(
+  //     environment,
+  //     ConnectionType.Follow,
+  //     PrivacyType.Public,
+  //   );
 
-    const connect_action: ConnectAction = {
-      type: "Connect",
-      ownerDsnpUserId: "1",
-      connection: {
-        dsnpUserId: "2",
-        schemaId: public_follow_graph_schema_id,
-      } as Connection,
-      dsnpKeys: {
-        dsnpUserId: "2",
-        keysHash: 100,
-        keys: [],
-      } as DsnpKeys,
-    } as ConnectAction;
+  //   const connect_action: ConnectAction = {
+  //     type: "Connect",
+  //     ownerDsnpUserId: "1",
+  //     connection: {
+  //       dsnpUserId: "2",
+  //       schemaId: public_follow_graph_schema_id,
+  //     } as Connection,
+  //     dsnpKeys: {
+  //       dsnpUserId: "2",
+  //       keysHash: 100,
+  //       keys: [],
+  //     } as DsnpKeys,
+  //   } as ConnectAction;
 
-    const actions = [] as Action[];
-    actions.push(connect_action);
-    const applied = graph.applyActions(actions);
-    expect(applied).toEqual(true);
+  //   const actions = [] as Action[];
+  //   actions.push(connect_action);
+  //   const applied = graph.applyActions(actions);
+  //   expect(applied).toEqual(true);
 
-    const connections_including_pending = graph.getConnectionsForUserGraph(
-      "1",
-      public_follow_graph_schema_id,
-      true,
-    );
+  //   const connections_including_pending = graph.getConnectionsForUserGraph(
+  //     "1",
+  //     public_follow_graph_schema_id,
+  //     true,
+  //   );
 
-    expect(connections_including_pending).toBeDefined();
-    expect(connections_including_pending.length).toEqual(1);
+  //   expect(connections_including_pending).toBeDefined();
+  //   expect(connections_including_pending.length).toEqual(1);
 
-    const exported = graph.exportUpdates();
-    expect(exported).toBeDefined();
-    expect(exported.length).toEqual(1);
-  });
+  //   const exported = graph.exportUpdates();
+  //   expect(exported).toBeDefined();
+  //   expect(exported.length).toEqual(1);
+  // });
 
-  test("Test exportGraph all-user and single-user variants", async () => {
-    const publicFollowGraphSchemaId = graph.getSchemaIdFromConfig(
-      environment,
-      ConnectionType.Follow,
-      PrivacyType.Public,
-    );
+  // test("Test exportGraph all-user and single-user variants", async () => {
+  //   const publicFollowGraphSchemaId = graph.getSchemaIdFromConfig(
+  //     environment,
+  //     ConnectionType.Follow,
+  //     PrivacyType.Public,
+  //   );
 
-    const actions: Action[] = [
-      {
-        type: "Connect",
-        ownerDsnpUserId: "1",
-        connection: {
-          dsnpUserId: "2",
-          schemaId: publicFollowGraphSchemaId,
-        },
-      },
-      {
-        type: "Connect",
-        ownerDsnpUserId: "2",
-        connection: {
-          dsnpUserId: "1",
-          schemaId: publicFollowGraphSchemaId,
-        },
-      },
-    ];
-    const applied = graph.applyActions(actions);
-    expect(applied).toEqual(true);
+  //   const actions: Action[] = [
+  //     {
+  //       type: "Connect",
+  //       ownerDsnpUserId: "1",
+  //       connection: {
+  //         dsnpUserId: "2",
+  //         schemaId: publicFollowGraphSchemaId,
+  //       },
+  //     },
+  //     {
+  //       type: "Connect",
+  //       ownerDsnpUserId: "2",
+  //       connection: {
+  //         dsnpUserId: "1",
+  //         schemaId: publicFollowGraphSchemaId,
+  //       },
+  //     },
+  //   ];
+  //   const applied = graph.applyActions(actions);
+  //   expect(applied).toEqual(true);
 
-    // Check that exportUpdates exports all users
-    let exported = graph.exportUpdates();
-    expect(exported).toBeDefined();
-    expect(exported.length).toEqual(2);
-    expect(
-      exported.every((bundle) =>
-        ["1", "2"].some((user) => user === bundle.ownerDsnpUserId),
-      ),
-    );
+  //   // Check that exportUpdates exports all users
+  //   let exported = graph.exportUpdates();
+  //   expect(exported).toBeDefined();
+  //   expect(exported.length).toEqual(2);
+  //   expect(
+  //     exported.every((bundle) =>
+  //       ["1", "2"].some((user) => user === bundle.ownerDsnpUserId),
+  //     ),
+  //   );
 
-    // Check that single-user export contains only that user
-    exported = graph.exportUserGraphUpdates("1");
-    expect(exported).toBeDefined();
-    expect(exported.length).toEqual(1);
-    expect(exported.every((bundle) => bundle.ownerDsnpUserId === "1"));
-  });
+  //   // Check that single-user export contains only that user
+  //   exported = graph.exportUserGraphUpdates("1");
+  //   expect(exported).toBeDefined();
+  //   expect(exported.length).toEqual(1);
+  //   expect(exported.every((bundle) => bundle.ownerDsnpUserId === "1"));
+  // });
 
-  test("Add a new graph key", async () => {
-    const dsnpOwnerId = 1;
-    const x25519_public_key = [
-      15, 234, 44, 175, 171, 220, 131, 117, 43, 227, 111, 165, 52, 150, 64, 218,
-      44, 130, 138, 221, 10, 41, 13, 241, 60, 210, 216, 23, 62, 178, 73, 111,
-    ];
+  // test("Add a new graph key", async () => {
+  //   const dsnpOwnerId = 1;
+  //   const x25519_public_key = [
+  //     15, 234, 44, 175, 171, 220, 131, 117, 43, 227, 111, 165, 52, 150, 64, 218,
+  //     44, 130, 138, 221, 10, 41, 13, 241, 60, 210, 216, 23, 62, 178, 73, 111,
+  //   ];
 
-    const addGraphKeyAction = {
-      type: "AddGraphKey",
-      ownerDsnpUserId: dsnpOwnerId.toString(),
-      newPublicKey: new Uint8Array(x25519_public_key),
-    } as AddGraphKeyAction;
+  //   const addGraphKeyAction = {
+  //     type: "AddGraphKey",
+  //     ownerDsnpUserId: dsnpOwnerId.toString(),
+  //     newPublicKey: new Uint8Array(x25519_public_key),
+  //   } as AddGraphKeyAction;
 
-    const actions = [] as Action[];
-    actions.push(addGraphKeyAction);
+  //   const actions = [] as Action[];
+  //   actions.push(addGraphKeyAction);
 
-    const applied = graph.applyActions(actions);
-    expect(applied).toEqual(true);
+  //   const applied = graph.applyActions(actions);
+  //   expect(applied).toEqual(true);
 
-    const exported = graph.exportUpdates();
-    expect(exported).toBeDefined();
-    expect(exported.length).toEqual(1);
-  });
+  //   const exported = graph.exportUpdates();
+  //   expect(exported).toBeDefined();
+  //   expect(exported.length).toEqual(1);
+  // });
 
-  test("Read and deserialize published graph keys", async () => {
-    const dsnp_key_owner = 1000;
+  // test("Read and deserialize published graph keys", async () => {
+  //   const dsnp_key_owner = 1000;
 
-    // published keys blobs fetched from blockchain
-    const published_keys_blob = [
-      64, 15, 234, 44, 175, 171, 220, 131, 117, 43, 227, 111, 165, 52, 150, 64,
-      218, 44, 130, 138, 221, 10, 41, 13, 241, 60, 210, 216, 23, 62, 178, 73,
-      111,
-    ];
-    const dsnp_keys = {
-      dsnpUserId: dsnp_key_owner.toString(),
-      keysHash: 100,
-      keys: [
-        {
-          index: 0,
-          content: new Uint8Array(published_keys_blob),
-        },
-      ] as KeyData[],
-    } as DsnpKeys;
+  //   // published keys blobs fetched from blockchain
+  //   const published_keys_blob = [
+  //     64, 15, 234, 44, 175, 171, 220, 131, 117, 43, 227, 111, 165, 52, 150, 64,
+  //     218, 44, 130, 138, 221, 10, 41, 13, 241, 60, 210, 216, 23, 62, 178, 73,
+  //     111,
+  //   ];
+  //   const dsnp_keys = {
+  //     dsnpUserId: dsnp_key_owner.toString(),
+  //     keysHash: 100,
+  //     keys: [
+  //       {
+  //         index: 0,
+  //         content: new Uint8Array(published_keys_blob),
+  //       },
+  //     ] as KeyData[],
+  //   } as DsnpKeys;
 
-    const deserialized_keys = Graph.deserializeDsnpKeys(dsnp_keys);
-    expect(deserialized_keys).toBeDefined();
-  });
+  //   const deserialized_keys = Graph.deserializeDsnpKeys(dsnp_keys);
+  //   expect(deserialized_keys).toBeDefined();
+  // });
 
-  test("generateKeyPair should return a key pair", async () => {
-    const keyPair = Graph.generateKeyPair(GraphKeyType.X25519);
-    expect(keyPair).toBeDefined();
-    expect(keyPair.publicKey).toBeDefined();
-    expect(keyPair.secretKey).toBeDefined();
-    expect(keyPair.keyType).toEqual(GraphKeyType.X25519);
-  });
+  // test("generateKeyPair should return a key pair", async () => {
+  //   const keyPair = Graph.generateKeyPair(GraphKeyType.X25519);
+  //   expect(keyPair).toBeDefined();
+  //   expect(keyPair.publicKey).toBeDefined();
+  //   expect(keyPair.secretKey).toBeDefined();
+  //   expect(keyPair.keyType).toEqual(GraphKeyType.X25519);
+  // });
 
   test("Import bundle without schema id and empty pages should import keys", async () => {
-    const dsnpUserId = "1";
-    const keyPair = Graph.generateKeyPair(GraphKeyType.X25519);
+    const dsnpUserId = "1000";
+    const keyPair: GraphKeyPair = {
+      publicKey: Uint8Array.from(
+        Buffer.from(
+          "e3b18e1aa5c84175ec0c516838fb89dd9c947dd348fa38fe2082764bbc82a86f",
+          "hex",
+        ),
+      ),
+      secretKey: Uint8Array.from(
+        Buffer.from(
+          "a55688dc2ffcf0f2b7e819029ad686a3c896c585725f5ac38dddace7de703451",
+          "hex",
+        ),
+      ),
+      keyType: GraphKeyType.X25519,
+    };
+
     const keyPairs = [keyPair];
     const dsnpKeys = {
       dsnpUserId,
@@ -494,13 +509,14 @@ describe("Graph tests", () => {
       keys: [
         {
           index: 0,
-          content: keyPair.publicKey,
+          content:Uint8Array.from(Buffer.from('40e3b18e1aa5c84175ec0c516838fb89dd9c947dd348fa38fe2082764bbc82a86f', 'hex')),
         },
       ] as KeyData[],
     } as DsnpKeys;
 
     const importBundle: ImportBundle = {
       dsnpUserId,
+      schemaId: 0,
       keyPairs,
       dsnpKeys,
       pages: [],

--- a/bridge/node/js/graph.test.ts
+++ b/bridge/node/js/graph.test.ts
@@ -41,9 +41,14 @@ const config: Config = {
     2: {
       dsnpVersion: DsnpVersion.Version1_0,
       connectionType: ConnectionType.Follow,
-      privacyType: PrivacyType.Private,
+      privacyType: PrivacyType.Public,
     },
     3: {
+      dsnpVersion: DsnpVersion.Version1_0,
+      connectionType: ConnectionType.Follow,
+      privacyType: PrivacyType.Private,
+    },
+    4: {
       dsnpVersion: DsnpVersion.Version1_0,
       connectionType: ConnectionType.Friendship,
       privacyType: PrivacyType.Private,
@@ -484,7 +489,7 @@ describe("Graph tests", () => {
     expect(keyPair.keyType).toEqual(GraphKeyType.X25519);
   });
 
-  test("Import bundle without schema id and empty pages should import keys", async () => {
+  test("Private Graph: Import bundle without schema id and empty pages should import keys", async () => {
     const dsnpUserId = "1000";
     const keyPair: GraphKeyPair = {
       publicKey: Uint8Array.from(
@@ -524,8 +529,21 @@ describe("Graph tests", () => {
 
     const imported = graph.importUserData([importBundle]);
     expect(imported).toEqual(true);
+    let connectionPrivate: Connection = {
+      dsnpUserId: "1000",
+      schemaId: 3,
+    };
 
+    let privateConnectAction: ConnectAction ={
+      type: "Connect",
+      ownerDsnpUserId: "1000",
+      dsnpKeys,
+      connection: connectionPrivate,
+    }
+    const appliedAction = await  graph.applyActions([privateConnectAction]);
+    expect(appliedAction).toEqual(true);
     const exported = graph.exportUpdates();
     expect(exported).toBeDefined();
+    expect(exported.length).toEqual(1);
   });
 });

--- a/bridge/node/js/graph.test.ts
+++ b/bridge/node/js/graph.test.ts
@@ -483,4 +483,34 @@ describe("Graph tests", () => {
     expect(keyPair.secretKey).toBeDefined();
     expect(keyPair.keyType).toEqual(GraphKeyType.X25519);
   });
+
+  test("Import bundle without schema id and empty pages should import keys", async () => {
+    const dsnpUserId = "1";
+    const keyPair = Graph.generateKeyPair(GraphKeyType.X25519);
+    const keyPairs = [keyPair];
+    const dsnpKeys = {
+      dsnpUserId,
+      keysHash: 100,
+      keys: [
+        {
+          index: 0,
+          content: keyPair.publicKey,
+        },
+      ] as KeyData[],
+    } as DsnpKeys;
+
+    const importBundle: ImportBundle = {
+      dsnpUserId,
+      keyPairs,
+      dsnpKeys,
+      pages: [],
+    };
+
+    const imported = graph.importUserData([importBundle]);
+    expect(imported).toEqual(true);
+
+    const exported = graph.exportUpdates();
+    expect(exported).toBeDefined();
+    expect(exported.length).toEqual(1);
+  });
 });

--- a/bridge/node/js/graph.test.ts
+++ b/bridge/node/js/graph.test.ts
@@ -527,6 +527,5 @@ describe("Graph tests", () => {
 
     const exported = graph.exportUpdates();
     expect(exported).toBeDefined();
-    expect(exported.length).toEqual(1);
   });
 });

--- a/bridge/node/js/graph.test.ts
+++ b/bridge/node/js/graph.test.ts
@@ -70,419 +70,419 @@ describe("Graph tests", () => {
     graph.freeGraphState();
   });
 
-  // test('printHelloGraph should print "Hello, Graph!"', async () => {
-  //   // Mock the console.log function
-  //   const consoleLogMock = jest.spyOn(console, "log").mockImplementation();
-  //   graph.printHelloGraph();
-  //   expect(consoleLogMock).toHaveBeenCalledWith("Hello, Graph!");
-  // });
+  test('printHelloGraph should print "Hello, Graph!"', async () => {
+    // Mock the console.log function
+    const consoleLogMock = jest.spyOn(console, "log").mockImplementation();
+    graph.printHelloGraph();
+    expect(consoleLogMock).toHaveBeenCalledWith("Hello, Graph!");
+  });
 
-  // test("getGraphConfig should return the graph config", async () => {
-  //   const config_ret = graph.getGraphConfig(environment);
-  //   expect(config_ret).toBeDefined();
-  //   expect(config_ret.graphPublicKeySchemaId).toEqual(11);
-  // });
+  test("getGraphConfig should return the graph config", async () => {
+    const config_ret = graph.getGraphConfig(environment);
+    expect(config_ret).toBeDefined();
+    expect(config_ret.graphPublicKeySchemaId).toEqual(11);
+  });
 
-  // test("getGraphConfig with Mainnet environment should return the graph config", async () => {
-  //   const environment: EnvironmentInterface = {
-  //     environmentType: EnvironmentType.Mainnet,
-  //   };
-  //   const graph = new Graph(environment);
-  //   const config = graph.getGraphConfig(environment);
-  //   expect(config).toBeDefined();
-  //   expect(config.graphPublicKeySchemaId).toEqual(7);
-  //   const schema_id = graph.getSchemaIdFromConfig(
-  //     environment,
-  //     ConnectionType.Follow,
-  //     PrivacyType.Public,
-  //   );
-  //   expect(schema_id).toEqual(8);
-  //   graph.freeGraphState();
-  // });
+  test("getGraphConfig with Mainnet environment should return the graph config", async () => {
+    const environment: EnvironmentInterface = {
+      environmentType: EnvironmentType.Mainnet,
+    };
+    const graph = new Graph(environment);
+    const config = graph.getGraphConfig(environment);
+    expect(config).toBeDefined();
+    expect(config.graphPublicKeySchemaId).toEqual(7);
+    const schema_id = graph.getSchemaIdFromConfig(
+      environment,
+      ConnectionType.Follow,
+      PrivacyType.Public,
+    );
+    expect(schema_id).toEqual(8);
+    graph.freeGraphState();
+  });
 
-  // test("getGraphConfig with Rococo environment should return the graph config", async () => {
-  //   const environment: EnvironmentInterface = {
-  //     environmentType: EnvironmentType.Rococo,
-  //   };
-  //   const graph = new Graph(environment);
-  //   const config = graph.getGraphConfig(environment);
-  //   expect(config).toBeDefined();
-  //   graph.freeGraphState();
-  // });
+  test("getGraphConfig with Rococo environment should return the graph config", async () => {
+    const environment: EnvironmentInterface = {
+      environmentType: EnvironmentType.Rococo,
+    };
+    const graph = new Graph(environment);
+    const config = graph.getGraphConfig(environment);
+    expect(config).toBeDefined();
+    graph.freeGraphState();
+  });
 
-  // test("getGraphStatesCount should be unchanged after create/free new graph", async () => {
-  //   const originalCount = graph.getGraphStatesCount();
-  //   const secondGraph = new Graph(environment);
-  //   secondGraph.freeGraphState();
-  //   expect(secondGraph.getGraphStatesCount()).toEqual(originalCount);
-  // });
+  test("getGraphStatesCount should be unchanged after create/free new graph", async () => {
+    const originalCount = graph.getGraphStatesCount();
+    const secondGraph = new Graph(environment);
+    secondGraph.freeGraphState();
+    expect(secondGraph.getGraphStatesCount()).toEqual(originalCount);
+  });
 
-  // test("getGraphStatesCount should be one after graph is initialized", async () => {
-  //   const count = graph.getGraphStatesCount();
-  //   expect(count).toEqual(1);
-  // });
+  test("getGraphStatesCount should be one after graph is initialized", async () => {
+    const count = graph.getGraphStatesCount();
+    expect(count).toEqual(1);
+  });
 
-  // test("getGraphUsersCount should be zero on initialized graph", async () => {
-  //   const count = graph.getGraphUsersCount();
-  //   expect(count).toEqual(0);
-  // });
+  test("getGraphUsersCount should be zero on initialized graph", async () => {
+    const count = graph.getGraphUsersCount();
+    expect(count).toEqual(0);
+  });
 
-  // test("containsUserGraph should return false on initialized graph", async () => {
-  //   const contains = graph.containsUserGraph("1");
-  //   expect(contains).toEqual(false);
-  // });
+  test("containsUserGraph should return false on initialized graph", async () => {
+    const contains = graph.containsUserGraph("1");
+    expect(contains).toEqual(false);
+  });
 
-  // test("removeUserGraph should pass through on initialized graph", async () => {
-  //   const removed = graph.removeUserGraph("1");
-  //   expect(removed).toEqual(true);
-  // });
+  test("removeUserGraph should pass through on initialized graph", async () => {
+    const removed = graph.removeUserGraph("1");
+    expect(removed).toEqual(true);
+  });
 
-  // test("importUserData should pass through on initialized graph", async () => {
-  //   // Set up import data
-  //   const dsnpUserId1 = 1;
-  //   const dsnpUserId2 = 2;
+  test("importUserData should pass through on initialized graph", async () => {
+    // Set up import data
+    const dsnpUserId1 = 1;
+    const dsnpUserId2 = 2;
 
-  //   const pageData1: PageData = {
-  //     pageId: 1,
-  //     content: new Uint8Array([
-  //       24, 227, 96, 97, 96, 99, 224, 96, 224, 98, 96, 0, 0,
-  //     ]),
-  //     contentHash: 100,
-  //   };
+    const pageData1: PageData = {
+      pageId: 1,
+      content: new Uint8Array([
+        24, 227, 96, 97, 96, 99, 224, 96, 224, 98, 96, 0, 0,
+      ]),
+      contentHash: 100,
+    };
 
-  //   const keyPairs1: GraphKeyPair[] = [];
-  //   const keyPairs2: GraphKeyPair[] = [];
+    const keyPairs1: GraphKeyPair[] = [];
+    const keyPairs2: GraphKeyPair[] = [];
 
-  //   const dsnpKeys1: DsnpKeys = {
-  //     dsnpUserId: dsnpUserId1.toString(),
-  //     keysHash: 100,
-  //     keys: [],
-  //   };
+    const dsnpKeys1: DsnpKeys = {
+      dsnpUserId: dsnpUserId1.toString(),
+      keysHash: 100,
+      keys: [],
+    };
 
-  //   const dsnpKeys2: DsnpKeys = {
-  //     dsnpUserId: dsnpUserId2.toString(),
-  //     keysHash: 100,
-  //     keys: [],
-  //   };
+    const dsnpKeys2: DsnpKeys = {
+      dsnpUserId: dsnpUserId2.toString(),
+      keysHash: 100,
+      keys: [],
+    };
 
-  //   const importBundle1: ImportBundle = {
-  //     dsnpUserId: dsnpUserId1.toString(),
-  //     schemaId: 1,
-  //     keyPairs: keyPairs1,
-  //     dsnpKeys: dsnpKeys1,
-  //     pages: [pageData1],
-  //   };
+    const importBundle1: ImportBundle = {
+      dsnpUserId: dsnpUserId1.toString(),
+      schemaId: 1,
+      keyPairs: keyPairs1,
+      dsnpKeys: dsnpKeys1,
+      pages: [pageData1],
+    };
 
-  //   const importBundle2: ImportBundle = {
-  //     dsnpUserId: dsnpUserId2.toString(),
-  //     schemaId: 1,
-  //     keyPairs: keyPairs2,
-  //     dsnpKeys: dsnpKeys2,
-  //     pages: [pageData1],
-  //   };
+    const importBundle2: ImportBundle = {
+      dsnpUserId: dsnpUserId2.toString(),
+      schemaId: 1,
+      keyPairs: keyPairs2,
+      dsnpKeys: dsnpKeys2,
+      pages: [pageData1],
+    };
 
-  //   // Import user data for each ImportBundle
-  //   const imported = graph.importUserData([importBundle1, importBundle2]);
-  //   expect(imported).toEqual(true);
-  // });
+    // Import user data for each ImportBundle
+    const imported = graph.importUserData([importBundle1, importBundle2]);
+    expect(imported).toEqual(true);
+  });
 
-  // test("applyActions with empty actions should pass through on initialized graph", async () => {
-  //   // Set up actions
-  //   const actions = [] as Action[];
-  //   const applied = graph.applyActions(actions);
-  //   expect(applied).toEqual(true);
-  // });
+  test("applyActions with empty actions should pass through on initialized graph", async () => {
+    // Set up actions
+    const actions = [] as Action[];
+    const applied = graph.applyActions(actions);
+    expect(applied).toEqual(true);
+  });
 
-  // test("applyActions with some actions should pass through on initialized graph", async () => {
-  //   // Set up actions
-  //   const actions = [] as Action[];
-  //   const action_1 = {
-  //     type: "Connect",
-  //     ownerDsnpUserId: "1",
-  //     connection: {
-  //       dsnpUserId: "2",
-  //       schemaId: 1,
-  //     } as Connection,
-  //   } as ConnectAction;
+  test("applyActions with some actions should pass through on initialized graph", async () => {
+    // Set up actions
+    const actions = [] as Action[];
+    const action_1 = {
+      type: "Connect",
+      ownerDsnpUserId: "1",
+      connection: {
+        dsnpUserId: "2",
+        schemaId: 1,
+      } as Connection,
+    } as ConnectAction;
 
-  //   actions.push(action_1);
-  //   const applied = graph.applyActions(actions);
-  //   expect(applied).toEqual(true);
+    actions.push(action_1);
+    const applied = graph.applyActions(actions);
+    expect(applied).toEqual(true);
 
-  //   const exported = graph.exportUpdates();
-  //   expect(exported).toBeDefined();
-  //   expect(exported.length).toEqual(1);
-  // });
+    const exported = graph.exportUpdates();
+    expect(exported).toBeDefined();
+    expect(exported.length).toEqual(1);
+  });
 
-  // test("applyActions with options should honor options", async () => {
-  //   // Add some connections to 2 empty graphs
-  //   const dsnpId_1 = "1";
-  //   const dsnpId_2 = "2";
-  //   const schemaId = 1;
+  test("applyActions with options should honor options", async () => {
+    // Add some connections to 2 empty graphs
+    const dsnpId_1 = "1";
+    const dsnpId_2 = "2";
+    const schemaId = 1;
 
-  //   let actions: Action[] = [
-  //     {
-  //       type: "Connect",
-  //       ownerDsnpUserId: dsnpId_1,
-  //       connection: {
-  //         dsnpUserId: dsnpId_2,
-  //         schemaId,
-  //       },
-  //     },
-  //     {
-  //       type: "Connect",
-  //       ownerDsnpUserId: dsnpId_2,
-  //       connection: {
-  //         dsnpUserId: dsnpId_1,
-  //         schemaId,
-  //       },
-  //     },
-  //   ];
+    let actions: Action[] = [
+      {
+        type: "Connect",
+        ownerDsnpUserId: dsnpId_1,
+        connection: {
+          dsnpUserId: dsnpId_2,
+          schemaId,
+        },
+      },
+      {
+        type: "Connect",
+        ownerDsnpUserId: dsnpId_2,
+        connection: {
+          dsnpUserId: dsnpId_1,
+          schemaId,
+        },
+      },
+    ];
 
-  //   graph.applyActions(actions);
-  //   const exports: Update[] = graph.exportUpdates();
-  //   const imports = exports
-  //     .filter((update) => update.type === "PersistPage")
-  //     .map((update) => {
-  //       const persist = update as PersistPageUpdate;
-  //       const builder = new ImportBundleBuilder()
-  //         .withDsnpUserId(persist.ownerDsnpUserId)
-  //         .withSchemaId(persist.schemaId)
-  //         .withPageData(persist.pageId, persist.payload, 1000);
-  //       return builder.build();
-  //     });
+    graph.applyActions(actions);
+    const exports: Update[] = graph.exportUpdates();
+    const imports = exports
+      .filter((update) => update.type === "PersistPage")
+      .map((update) => {
+        const persist = update as PersistPageUpdate;
+        const builder = new ImportBundleBuilder()
+          .withDsnpUserId(persist.ownerDsnpUserId)
+          .withSchemaId(persist.schemaId)
+          .withPageData(persist.pageId, persist.payload, 1000);
+        return builder.build();
+      });
 
-  //   graph.importUserData(imports);
+    graph.importUserData(imports);
 
-  //   // Now we have graphs with connections, attempt to add redundant connection
-  //   actions = [
-  //     {
-  //       type: "Connect",
-  //       ownerDsnpUserId: dsnpId_1,
-  //       connection: {
-  //         dsnpUserId: dsnpId_2,
-  //         schemaId,
-  //       },
-  //     },
-  //   ];
-  //   expect(() => graph.applyActions(actions)).toThrow();
-  //   expect(() =>
-  //     graph.applyActions(actions, { ignoreExistingConnections: true }),
-  //   ).not.toThrow();
+    // Now we have graphs with connections, attempt to add redundant connection
+    actions = [
+      {
+        type: "Connect",
+        ownerDsnpUserId: dsnpId_1,
+        connection: {
+          dsnpUserId: dsnpId_2,
+          schemaId,
+        },
+      },
+    ];
+    expect(() => graph.applyActions(actions)).toThrow();
+    expect(() =>
+      graph.applyActions(actions, { ignoreExistingConnections: true }),
+    ).not.toThrow();
 
-  //   // Now try to remove a non-existent connection
-  //   actions = [
-  //     {
-  //       type: "Disconnect",
-  //       ownerDsnpUserId: dsnpId_1,
-  //       connection: {
-  //         dsnpUserId: "999",
-  //         schemaId,
-  //       },
-  //     },
-  //   ];
-  //   expect(() => graph.applyActions(actions)).toThrow();
-  //   expect(() =>
-  //     graph.applyActions(actions, { ignoreMissingConnections: true }),
-  //   ).not.toThrow();
-  // });
+    // Now try to remove a non-existent connection
+    actions = [
+      {
+        type: "Disconnect",
+        ownerDsnpUserId: dsnpId_1,
+        connection: {
+          dsnpUserId: "999",
+          schemaId,
+        },
+      },
+    ];
+    expect(() => graph.applyActions(actions)).toThrow();
+    expect(() =>
+      graph.applyActions(actions, { ignoreMissingConnections: true }),
+    ).not.toThrow();
+  });
 
-  // test("getConnectionsForUserGraph with empty connections should return empty array", async () => {
-  //   // Set up actions
-  //   const actions = [] as Action[];
-  //   const action_1 = {
-  //     type: "Connect",
-  //     ownerDsnpUserId: "1",
-  //     connection: {
-  //       dsnpUserId: "2",
-  //       schemaId: 1,
-  //     } as Connection,
-  //     dsnpKeys: {
-  //       dsnpUserId: "2",
-  //       keysHash: 100,
-  //       keys: [],
-  //     } as DsnpKeys,
-  //   } as ConnectAction;
+  test("getConnectionsForUserGraph with empty connections should return empty array", async () => {
+    // Set up actions
+    const actions = [] as Action[];
+    const action_1 = {
+      type: "Connect",
+      ownerDsnpUserId: "1",
+      connection: {
+        dsnpUserId: "2",
+        schemaId: 1,
+      } as Connection,
+      dsnpKeys: {
+        dsnpUserId: "2",
+        keysHash: 100,
+        keys: [],
+      } as DsnpKeys,
+    } as ConnectAction;
 
-  //   actions.push(action_1);
-  //   const applied = graph.applyActions(actions);
-  //   expect(applied).toEqual(true);
-  //   const connections = graph.getConnectionsForUserGraph("1", 1, true);
-  //   expect(connections).toBeDefined();
-  //   expect(connections.length).toEqual(1);
+    actions.push(action_1);
+    const applied = graph.applyActions(actions);
+    expect(applied).toEqual(true);
+    const connections = graph.getConnectionsForUserGraph("1", 1, true);
+    expect(connections).toBeDefined();
+    expect(connections.length).toEqual(1);
 
-  //   const forceCalculateGraphs = graph.forceCalculateGraphs("1");
-  //   expect(forceCalculateGraphs).toBeDefined();
-  //   expect(forceCalculateGraphs.length).toEqual(0);
-  // });
+    const forceCalculateGraphs = graph.forceCalculateGraphs("1");
+    expect(forceCalculateGraphs).toBeDefined();
+    expect(forceCalculateGraphs.length).toEqual(0);
+  });
 
-  // test("getConnectionsWithoutKeys with empty connections should return empty array", async () => {
-  //   const connections = graph.getConnectionsWithoutKeys();
-  //   expect(connections).toBeDefined();
-  //   expect(connections.length).toEqual(0);
+  test("getConnectionsWithoutKeys with empty connections should return empty array", async () => {
+    const connections = graph.getConnectionsWithoutKeys();
+    expect(connections).toBeDefined();
+    expect(connections.length).toEqual(0);
 
-  //   expect(() => graph.getOneSidedPrivateFriendshipConnections("1")).toThrow(
-  //     "User graph for 1 is not imported",
-  //   );
-  // });
+    expect(() => graph.getOneSidedPrivateFriendshipConnections("1")).toThrow(
+      "User graph for 1 is not imported",
+    );
+  });
 
-  // test("getPublicKeys with empty connections should return empty array", async () => {
-  //   const keys = graph.getPublicKeys("1");
-  //   expect(keys).toBeDefined();
-  //   expect(keys.length).toEqual(0);
-  // });
+  test("getPublicKeys with empty connections should return empty array", async () => {
+    const keys = graph.getPublicKeys("1");
+    expect(keys).toBeDefined();
+    expect(keys.length).toEqual(0);
+  });
 
-  // test("deserializeDsnpKeys with empty keys should return empty array", async () => {
-  //   const keys = {
-  //     dsnpUserId: "2",
-  //     keysHash: 100,
-  //     keys: [],
-  //   } as DsnpKeys;
-  //   const des_keys = Graph.deserializeDsnpKeys(keys);
-  //   expect(des_keys).toBeDefined();
-  //   expect(des_keys.length).toEqual(0);
-  // });
+  test("deserializeDsnpKeys with empty keys should return empty array", async () => {
+    const keys = {
+      dsnpUserId: "2",
+      keysHash: 100,
+      keys: [],
+    } as DsnpKeys;
+    const des_keys = Graph.deserializeDsnpKeys(keys);
+    expect(des_keys).toBeDefined();
+    expect(des_keys.length).toEqual(0);
+  });
 
-  // test("Create and export a new graph", async () => {
-  //   const public_follow_graph_schema_id = graph.getSchemaIdFromConfig(
-  //     environment,
-  //     ConnectionType.Follow,
-  //     PrivacyType.Public,
-  //   );
+  test("Create and export a new graph", async () => {
+    const public_follow_graph_schema_id = graph.getSchemaIdFromConfig(
+      environment,
+      ConnectionType.Follow,
+      PrivacyType.Public,
+    );
 
-  //   const connect_action: ConnectAction = {
-  //     type: "Connect",
-  //     ownerDsnpUserId: "1",
-  //     connection: {
-  //       dsnpUserId: "2",
-  //       schemaId: public_follow_graph_schema_id,
-  //     } as Connection,
-  //     dsnpKeys: {
-  //       dsnpUserId: "2",
-  //       keysHash: 100,
-  //       keys: [],
-  //     } as DsnpKeys,
-  //   } as ConnectAction;
+    const connect_action: ConnectAction = {
+      type: "Connect",
+      ownerDsnpUserId: "1",
+      connection: {
+        dsnpUserId: "2",
+        schemaId: public_follow_graph_schema_id,
+      } as Connection,
+      dsnpKeys: {
+        dsnpUserId: "2",
+        keysHash: 100,
+        keys: [],
+      } as DsnpKeys,
+    } as ConnectAction;
 
-  //   const actions = [] as Action[];
-  //   actions.push(connect_action);
-  //   const applied = graph.applyActions(actions);
-  //   expect(applied).toEqual(true);
+    const actions = [] as Action[];
+    actions.push(connect_action);
+    const applied = graph.applyActions(actions);
+    expect(applied).toEqual(true);
 
-  //   const connections_including_pending = graph.getConnectionsForUserGraph(
-  //     "1",
-  //     public_follow_graph_schema_id,
-  //     true,
-  //   );
+    const connections_including_pending = graph.getConnectionsForUserGraph(
+      "1",
+      public_follow_graph_schema_id,
+      true,
+    );
 
-  //   expect(connections_including_pending).toBeDefined();
-  //   expect(connections_including_pending.length).toEqual(1);
+    expect(connections_including_pending).toBeDefined();
+    expect(connections_including_pending.length).toEqual(1);
 
-  //   const exported = graph.exportUpdates();
-  //   expect(exported).toBeDefined();
-  //   expect(exported.length).toEqual(1);
-  // });
+    const exported = graph.exportUpdates();
+    expect(exported).toBeDefined();
+    expect(exported.length).toEqual(1);
+  });
 
-  // test("Test exportGraph all-user and single-user variants", async () => {
-  //   const publicFollowGraphSchemaId = graph.getSchemaIdFromConfig(
-  //     environment,
-  //     ConnectionType.Follow,
-  //     PrivacyType.Public,
-  //   );
+  test("Test exportGraph all-user and single-user variants", async () => {
+    const publicFollowGraphSchemaId = graph.getSchemaIdFromConfig(
+      environment,
+      ConnectionType.Follow,
+      PrivacyType.Public,
+    );
 
-  //   const actions: Action[] = [
-  //     {
-  //       type: "Connect",
-  //       ownerDsnpUserId: "1",
-  //       connection: {
-  //         dsnpUserId: "2",
-  //         schemaId: publicFollowGraphSchemaId,
-  //       },
-  //     },
-  //     {
-  //       type: "Connect",
-  //       ownerDsnpUserId: "2",
-  //       connection: {
-  //         dsnpUserId: "1",
-  //         schemaId: publicFollowGraphSchemaId,
-  //       },
-  //     },
-  //   ];
-  //   const applied = graph.applyActions(actions);
-  //   expect(applied).toEqual(true);
+    const actions: Action[] = [
+      {
+        type: "Connect",
+        ownerDsnpUserId: "1",
+        connection: {
+          dsnpUserId: "2",
+          schemaId: publicFollowGraphSchemaId,
+        },
+      },
+      {
+        type: "Connect",
+        ownerDsnpUserId: "2",
+        connection: {
+          dsnpUserId: "1",
+          schemaId: publicFollowGraphSchemaId,
+        },
+      },
+    ];
+    const applied = graph.applyActions(actions);
+    expect(applied).toEqual(true);
 
-  //   // Check that exportUpdates exports all users
-  //   let exported = graph.exportUpdates();
-  //   expect(exported).toBeDefined();
-  //   expect(exported.length).toEqual(2);
-  //   expect(
-  //     exported.every((bundle) =>
-  //       ["1", "2"].some((user) => user === bundle.ownerDsnpUserId),
-  //     ),
-  //   );
+    // Check that exportUpdates exports all users
+    let exported = graph.exportUpdates();
+    expect(exported).toBeDefined();
+    expect(exported.length).toEqual(2);
+    expect(
+      exported.every((bundle) =>
+        ["1", "2"].some((user) => user === bundle.ownerDsnpUserId),
+      ),
+    );
 
-  //   // Check that single-user export contains only that user
-  //   exported = graph.exportUserGraphUpdates("1");
-  //   expect(exported).toBeDefined();
-  //   expect(exported.length).toEqual(1);
-  //   expect(exported.every((bundle) => bundle.ownerDsnpUserId === "1"));
-  // });
+    // Check that single-user export contains only that user
+    exported = graph.exportUserGraphUpdates("1");
+    expect(exported).toBeDefined();
+    expect(exported.length).toEqual(1);
+    expect(exported.every((bundle) => bundle.ownerDsnpUserId === "1"));
+  });
 
-  // test("Add a new graph key", async () => {
-  //   const dsnpOwnerId = 1;
-  //   const x25519_public_key = [
-  //     15, 234, 44, 175, 171, 220, 131, 117, 43, 227, 111, 165, 52, 150, 64, 218,
-  //     44, 130, 138, 221, 10, 41, 13, 241, 60, 210, 216, 23, 62, 178, 73, 111,
-  //   ];
+  test("Add a new graph key", async () => {
+    const dsnpOwnerId = 1;
+    const x25519_public_key = [
+      15, 234, 44, 175, 171, 220, 131, 117, 43, 227, 111, 165, 52, 150, 64, 218,
+      44, 130, 138, 221, 10, 41, 13, 241, 60, 210, 216, 23, 62, 178, 73, 111,
+    ];
 
-  //   const addGraphKeyAction = {
-  //     type: "AddGraphKey",
-  //     ownerDsnpUserId: dsnpOwnerId.toString(),
-  //     newPublicKey: new Uint8Array(x25519_public_key),
-  //   } as AddGraphKeyAction;
+    const addGraphKeyAction = {
+      type: "AddGraphKey",
+      ownerDsnpUserId: dsnpOwnerId.toString(),
+      newPublicKey: new Uint8Array(x25519_public_key),
+    } as AddGraphKeyAction;
 
-  //   const actions = [] as Action[];
-  //   actions.push(addGraphKeyAction);
+    const actions = [] as Action[];
+    actions.push(addGraphKeyAction);
 
-  //   const applied = graph.applyActions(actions);
-  //   expect(applied).toEqual(true);
+    const applied = graph.applyActions(actions);
+    expect(applied).toEqual(true);
 
-  //   const exported = graph.exportUpdates();
-  //   expect(exported).toBeDefined();
-  //   expect(exported.length).toEqual(1);
-  // });
+    const exported = graph.exportUpdates();
+    expect(exported).toBeDefined();
+    expect(exported.length).toEqual(1);
+  });
 
-  // test("Read and deserialize published graph keys", async () => {
-  //   const dsnp_key_owner = 1000;
+  test("Read and deserialize published graph keys", async () => {
+    const dsnp_key_owner = 1000;
 
-  //   // published keys blobs fetched from blockchain
-  //   const published_keys_blob = [
-  //     64, 15, 234, 44, 175, 171, 220, 131, 117, 43, 227, 111, 165, 52, 150, 64,
-  //     218, 44, 130, 138, 221, 10, 41, 13, 241, 60, 210, 216, 23, 62, 178, 73,
-  //     111,
-  //   ];
-  //   const dsnp_keys = {
-  //     dsnpUserId: dsnp_key_owner.toString(),
-  //     keysHash: 100,
-  //     keys: [
-  //       {
-  //         index: 0,
-  //         content: new Uint8Array(published_keys_blob),
-  //       },
-  //     ] as KeyData[],
-  //   } as DsnpKeys;
+    // published keys blobs fetched from blockchain
+    const published_keys_blob = [
+      64, 15, 234, 44, 175, 171, 220, 131, 117, 43, 227, 111, 165, 52, 150, 64,
+      218, 44, 130, 138, 221, 10, 41, 13, 241, 60, 210, 216, 23, 62, 178, 73,
+      111,
+    ];
+    const dsnp_keys = {
+      dsnpUserId: dsnp_key_owner.toString(),
+      keysHash: 100,
+      keys: [
+        {
+          index: 0,
+          content: new Uint8Array(published_keys_blob),
+        },
+      ] as KeyData[],
+    } as DsnpKeys;
 
-  //   const deserialized_keys = Graph.deserializeDsnpKeys(dsnp_keys);
-  //   expect(deserialized_keys).toBeDefined();
-  // });
+    const deserialized_keys = Graph.deserializeDsnpKeys(dsnp_keys);
+    expect(deserialized_keys).toBeDefined();
+  });
 
-  // test("generateKeyPair should return a key pair", async () => {
-  //   const keyPair = Graph.generateKeyPair(GraphKeyType.X25519);
-  //   expect(keyPair).toBeDefined();
-  //   expect(keyPair.publicKey).toBeDefined();
-  //   expect(keyPair.secretKey).toBeDefined();
-  //   expect(keyPair.keyType).toEqual(GraphKeyType.X25519);
-  // });
+  test("generateKeyPair should return a key pair", async () => {
+    const keyPair = Graph.generateKeyPair(GraphKeyType.X25519);
+    expect(keyPair).toBeDefined();
+    expect(keyPair.publicKey).toBeDefined();
+    expect(keyPair.secretKey).toBeDefined();
+    expect(keyPair.keyType).toEqual(GraphKeyType.X25519);
+  });
 
   test("Import bundle without schema id and empty pages should import keys", async () => {
     const dsnpUserId = "1000";

--- a/bridge/node/js/models/import_bundle.ts
+++ b/bridge/node/js/models/import_bundle.ts
@@ -27,8 +27,8 @@ export interface PageData {
 
 export interface ImportBundle {
   dsnpUserId: string;
-  schemaId: number;
-  keyPairs: GraphKeyPair[];
+  schemaId?: number;
+  keyPairs?: GraphKeyPair[];
   dsnpKeys?: DsnpKeys;
-  pages: PageData[];
+  pages?: PageData[];
 }

--- a/bridge/node/js/models/import_bundle.ts
+++ b/bridge/node/js/models/import_bundle.ts
@@ -27,8 +27,8 @@ export interface PageData {
 
 export interface ImportBundle {
   dsnpUserId: string;
-  schemaId?: number;
-  keyPairs?: GraphKeyPair[];
+  schemaId: number;
+  keyPairs: GraphKeyPair[];
   dsnpKeys?: DsnpKeys;
-  pages?: PageData[];
+  pages: PageData[];
 }

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -419,8 +419,6 @@ impl GraphState {
 		for ImportBundle { schema_id, pages, dsnp_keys, dsnp_user_id, key_pairs } in payloads {
 			let connection_type_option =
 				self.environment.get_config().get_connection_type_from_schema_id(*schema_id);
-			print!("connection_type_option: {:?}", connection_type_option);
-			print!("schema_id: {:?}", schema_id);
 			let connection_type = match connection_type_option {
 				Some(connection_type) => connection_type,
 				None => {

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -441,6 +441,11 @@ impl GraphState {
 				user_key_manager.import_key_pairs(key_pairs.clone())?;
 			};
 
+			if pages.is_empty() {
+				// case where only keys are imported
+				continue
+			}
+
 			let dsnp_config = user_graph
 				.get_dsnp_config(*schema_id)
 				.ok_or(DsnpGraphError::InvalidSchemaId(*schema_id))?;
@@ -449,11 +454,6 @@ impl GraphState {
 				.graph_mut(&schema_id)
 				.ok_or(DsnpGraphError::InvalidSchemaId(*schema_id))?;
 			graph.clear();
-
-			if pages.is_empty() {
-				// case where only keys are imported
-				continue
-			}
 
 			let connection_type =
 				connection_type_option.ok_or(DsnpGraphError::InvalidSchemaId(*schema_id))?;

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -422,7 +422,7 @@ impl GraphState {
 			let connection_type = match connection_type_option {
 				Some(connection_type) => connection_type,
 				None => {
-					if pages.is_empty() && !key_pairs.is_empty() && !dsnp_keys.is_none() {
+					if pages.is_empty() && (!key_pairs.is_empty() || !dsnp_keys.is_none()) {
 						// This condition implies that only keys are being imported
 						ConnectionType::Follow(PrivacyType::Private)
 					} else {
@@ -455,7 +455,9 @@ impl GraphState {
 				// import key-pairs inside user key manager
 				user_key_manager.import_key_pairs(key_pairs.clone())?;
 			};
+
 			if pages.is_empty() {
+				// case where only keys are imported
 				continue
 			}
 

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -411,26 +411,10 @@ impl GraphState {
 	/// main data importing logic
 	#[log_result_err(Level::Error)]
 	fn do_import_users_data(&mut self, payloads: &Vec<ImportBundle>) -> DsnpGraphResult<()> {
-		// pre validate all bundles
 		for bundle in payloads {
 			bundle.validate()?;
 		}
-		// import bundles
 		for ImportBundle { schema_id, pages, dsnp_keys, dsnp_user_id, key_pairs } in payloads {
-			let connection_type_option =
-				self.environment.get_config().get_connection_type_from_schema_id(*schema_id);
-			let connection_type = match connection_type_option {
-				Some(connection_type) => connection_type,
-				None => {
-					if pages.is_empty() && (!key_pairs.is_empty() || !dsnp_keys.is_none()) {
-						// This condition implies that only keys are being imported
-						ConnectionType::Follow(PrivacyType::Private)
-					} else {
-						return Err(DsnpGraphError::InvalidSchemaId(*schema_id))
-					}
-				},
-			};
-
 			match dsnp_keys {
 				Some(dsnp_keys) => {
 					self.shared_state_manager
@@ -443,56 +427,64 @@ impl GraphState {
 				None => (),
 			};
 
-			let user_graph = self.get_or_create_user_graph(*dsnp_user_id)?;
+			// Retrieve connection type first to avoid borrow conflict
+			let connection_type = self
+				.environment
+				.get_config()
+				.get_connection_type_from_schema_id(*schema_id)
+				.ok_or(DsnpGraphError::InvalidSchemaId(*schema_id))?;
 
-			let include_secret_keys = !key_pairs.is_empty();
 			{
-				let mut user_key_manager = user_graph
-					.user_key_manager
-					.write()
-					.map_err(|_| DsnpGraphError::FailedtoWriteLock(USER_KEY_MANAGER.to_string()))?;
+				let user_graph = self.get_or_create_user_graph(*dsnp_user_id)?;
 
-				// import key-pairs inside user key manager
-				user_key_manager.import_key_pairs(key_pairs.clone())?;
-			};
+				let include_secret_keys = !key_pairs.is_empty();
+				{
+					let mut user_key_manager =
+						user_graph.user_key_manager.write().map_err(|_| {
+							DsnpGraphError::FailedtoWriteLock(USER_KEY_MANAGER.to_string())
+						})?;
 
-			if pages.is_empty() {
-				// case where only keys are imported
-				continue
-			}
+					user_key_manager.import_key_pairs(key_pairs.clone())?;
+				};
 
-			let dsnp_config = user_graph
-				.get_dsnp_config(*schema_id)
-				.ok_or(DsnpGraphError::InvalidSchemaId(*schema_id))?;
+				if pages.is_empty() {
+					continue
+				}
 
-			let graph = user_graph
-				.graph_mut(&schema_id)
-				.ok_or(DsnpGraphError::InvalidSchemaId(*schema_id))?;
-			graph.clear();
+				let dsnp_config = user_graph
+					.get_dsnp_config(*schema_id)
+					.ok_or(DsnpGraphError::InvalidSchemaId(*schema_id))?;
 
-			match connection_type.privacy_type() {
-				PrivacyType::Public => {
-					graph.import_public(connection_type, pages)?;
-					user_graph.sync_updates(*schema_id);
-				},
-				PrivacyType::Private => {
-					// private keys are provided try to import the graph
-					if include_secret_keys {
-						graph.import_private(&dsnp_config, connection_type, pages)?;
+				let graph = user_graph
+					.graph_mut(&schema_id)
+					.ok_or(DsnpGraphError::InvalidSchemaId(*schema_id))?;
+				graph.clear();
+				match connection_type.privacy_type() {
+					PrivacyType::Public => {
+						graph.import_public(connection_type, pages)?;
 						user_graph.sync_updates(*schema_id);
-					}
+					},
+					PrivacyType::Private => {
+						// private keys are provided try to import the graph
+						if include_secret_keys {
+							graph.import_private(&dsnp_config, connection_type, pages)?;
+							user_graph.sync_updates(*schema_id);
+						}
 
-					// since it's a private friendship import provided PRIs
-					if connection_type == ConnectionType::Friendship(PrivacyType::Private) {
-						self.shared_state_manager
-							.write()
-							.map_err(|_| {
-								DsnpGraphError::FailedtoWriteLock(SHARED_STATE_MANAGER.to_string())
-							})?
-							.import_pri(*dsnp_user_id, pages)?;
-					}
-				},
-			};
+						// since it's a private friendship import provided PRIs
+						if connection_type == ConnectionType::Friendship(PrivacyType::Private) {
+							self.shared_state_manager
+								.write()
+								.map_err(|_| {
+									DsnpGraphError::FailedtoWriteLock(
+										SHARED_STATE_MANAGER.to_string(),
+									)
+								})?
+								.import_pri(*dsnp_user_id, pages)?;
+						}
+					},
+				};
+			}
 		}
 		Ok(())
 	}

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -427,6 +427,11 @@ impl GraphState {
 				None => (),
 			};
 
+			if pages.is_empty() {
+				// case where only keys are imported
+				continue
+			}
+
 			// Retrieve connection type first to avoid borrow conflict
 			let connection_type = self
 				.environment
@@ -447,10 +452,6 @@ impl GraphState {
 					user_key_manager.import_key_pairs(key_pairs.clone())?;
 				};
 
-				if pages.is_empty() {
-					continue
-				}
-
 				let dsnp_config = user_graph
 					.get_dsnp_config(*schema_id)
 					.ok_or(DsnpGraphError::InvalidSchemaId(*schema_id))?;
@@ -459,6 +460,7 @@ impl GraphState {
 					.graph_mut(&schema_id)
 					.ok_or(DsnpGraphError::InvalidSchemaId(*schema_id))?;
 				graph.clear();
+
 				match connection_type.privacy_type() {
 					PrivacyType::Public => {
 						graph.import_public(connection_type, pages)?;

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -425,9 +425,7 @@ impl GraphState {
 				Some(connection_type) => connection_type,
 				None => {
 					if pages.is_empty() && !key_pairs.is_empty() && !dsnp_keys.is_none() {
-						// if this very condition is met, it means that the user is importing key(s)
-						// key(s) are used in private follow graph, so we can safely assume that the
-						// privacy type is private follow if only key(s) are provided
+						// This condition implies that only keys are being imported
 						ConnectionType::Follow(PrivacyType::Private)
 					} else {
 						return Err(DsnpGraphError::InvalidSchemaId(*schema_id))

--- a/core/src/api/api_types.rs
+++ b/core/src/api/api_types.rs
@@ -143,7 +143,7 @@ impl InputValidation for ImportBundle {
 		if self.dsnp_user_id == 0 {
 			return DsnpGraphResult::Err(InvalidDsnpUserId(self.dsnp_user_id))
 		}
-		if self.schema_id == 0 {
+		if self.schema_id == 0 && self.pages.len() > 0 {
 			return DsnpGraphResult::Err(InvalidSchemaId(self.schema_id))
 		}
 

--- a/core/src/api/api_types.rs
+++ b/core/src/api/api_types.rs
@@ -236,7 +236,6 @@ impl InputValidation for Connection {
 		if self.dsnp_user_id == 0 {
 			return DsnpGraphResult::Err(InvalidDsnpUserId(self.dsnp_user_id))
 		}
-		println!("schema_id: {}", self.schema_id);
 		if self.schema_id == 0 {
 			return DsnpGraphResult::Err(InvalidSchemaId(self.schema_id))
 		}

--- a/core/src/api/api_types.rs
+++ b/core/src/api/api_types.rs
@@ -236,6 +236,7 @@ impl InputValidation for Connection {
 		if self.dsnp_user_id == 0 {
 			return DsnpGraphResult::Err(InvalidDsnpUserId(self.dsnp_user_id))
 		}
+		println!("schema_id: {}", self.schema_id);
 		if self.schema_id == 0 {
 			return DsnpGraphResult::Err(InvalidSchemaId(self.schema_id))
 		}


### PR DESCRIPTION
# Goal
The goal of this PR is to set condition to allow importing `dsnpKeys` and `keyPairs` without schemaId

Closes #168 

# Checklist
- [x] Tests added
