### PR TITLE
Github action for release

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -76,26 +76,6 @@ jobs:
       - name: Cargo fmt
         run: make format-check
 
-  #  clippy:
-  #    name: Run clippy
-  #    runs-on: ubuntu-latest
-  #    steps:
-  #      - name: Checkout code
-  #        uses: actions/checkout@v3
-  #        with:
-  #          fetch-depth: 0
-  #
-  #      - name: Install Rust Toolchain
-  #        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-  #        with:
-  #          toolchain: stable
-  #          default: true
-  #          profile: minimal
-  #          target: wasm32-unknown-unknown
-  #
-  #      - name: Cargo clippy
-  #        run: make clippy
-
   deny:
     name: Cargo Deny
     runs-on: ubuntu-latest
@@ -203,16 +183,9 @@ jobs:
           while read line; do
               echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
-      - name: Upload Docs
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: ./target/doc
-      - name: Deploy Docs
-        uses: actions/deploy-pages@v2
-        id: deployment
 
   build_gradlew_jvm:
-    name: Build and Publish JVM
+    name: Build JVM
     runs-on: ubuntu-latest
     needs: [verify, test, lint, build]
     permissions:
@@ -230,12 +203,6 @@ jobs:
       - name: Build and Publish with Gradle
         working-directory: java
         run: ./gradlew build
-      - name: Publish to GitHub Packages
-        working-directory: java
-        run: ./gradlew publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTOR: ${{ github.actor }}
 
   build_test_node_bridge:
     name: Build and Test Node Bridge
@@ -274,65 +241,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
 
-  publish_npm_package:
-    name: Publish NPM Package
-    runs-on: ubuntu-latest
-    needs: [verify, test, lint, build, build_test_node_bridge]
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
-          registry-url: https://registry.npmjs.org/
-      - name: Install NPM Dependencies
-        working-directory: bridge/node
-        run: npm install
-      - name: Get current version
-        id: version
-        working-directory: bridge/node
-        run: echo ::set-output name=version::$(node -p "require('./package.json').version")
-
-      - name: Bump version
-        working-directory: bridge/node
-        run: |
-          # Increment the version based on semantic versioning rules
-          # Example: MAJOR version increment
-          # VERSION=$(node -p "const [major, minor, patch] = '${{ steps.version.outputs.version }}'.split('.'); `${parseInt(major) + 1}.0.0`")
-          VERSION=$(node -p "const [major, minor, patch] = '${{ steps.version.outputs.version }}'.split('.'); \`\${major}.\${minor}.\${parseInt(patch) + 1}\`")
-          npm version --new-version "$VERSION" --no-git-tag-version
-
-      - name: Use the new version
-        id: use-version
-        working-directory: bridge/node
-        run: |
-          NEW_VERSION=$(node -p "require('./package.json').version")
-          echo "New version: $NEW_VERSION"
-        env:
-          FULL_SHA: ${{ github.sha }}
-      - name: Build NPM Package
-        working-directory: bridge/node
-        run: npm run native:build-release && cp README.md dist/README.md
-      - name: Publish NPM Package
-        working-directory: bridge/node
-        if: github.ref == 'refs/heads/main'
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-      - name: Dry run NPM Package
-        working-directory: bridge/node
-        if: github.ref != 'refs/heads/main'
-        run: npm publish --access public --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-
   test_published_npm:
     name: Test Published NPM Package
     runs-on: ubuntu-latest
-    needs: [publish_npm_package]
+    needs: [verify, test, lint, build, build_gradlew_jvm]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,303 @@
+name: Release
+run-name: Release ${{github.event.inputs.release-version || github.ref_name}}
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+' # ex. v1.0.0
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+' # ex. v1.1.0-rc1  for pre-releases
+
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: "Release version (v#.#.#[-rc#])"
+        required: true
+
+env:
+  NEW_RELEASE_TAG: ${{github.event.inputs.release-version || github.ref_name}}
+  TEST_RUN: ${{contains(github.event.inputs.release-version || github.ref_name, '-rc')}}
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
+
+jobs:
+  verify:
+    name: Checks core project built in Rust
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal
+          target: wasm32-unknown-unknown
+
+      - name: Cargo check
+        run: make check
+
+      - name: Cargo test
+        run: make test
+
+      - name: Cargo fmt
+        run: make format-check
+
+      - name: Set Up Cargo Deny
+        run: |
+          cargo install --force cargo-deny
+          cargo generate-lockfile
+
+      - name: License and Issue Check
+        run: make deny
+
+  build-artifacts:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            java_library: libdsnp_graph_sdk_jni.so
+            node_library: libdsnp_graph_sdk_node.so
+          - os: windows-latest
+            java_library: dsnp_graph_sdk_jni.dll
+            node_library: dsnp_graph_sdk_node.dll
+          - os: macos-latest
+            java_library: libdsnp_graph_sdk_jni.dylib
+            node_library: libdsnp_graph_sdk_node.dylib
+            additional-rust-target: aarch64-apple-darwin
+
+    name: Build project in ${{ matrix.os }}
+    needs: verify
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal
+          target: wasm32-unknown-unknown
+
+      - run: rustup target add ${{ matrix.additional-rust-target }}
+        if: ${{ matrix.additional-rust-target != '' }}
+
+      - name: Set up Java
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Build Jni bridge
+        run: make build-jni
+
+      - name: Build Node bridge
+        run: make build-node
+
+      - name: Copy artifacts
+        run: |
+          mkdir artifacts
+          cp target/release/${{ matrix.java_library }} artifacts/${{ matrix.java_library }}
+          cp target/release/${{ matrix.node_library }} artifacts/${{ matrix.node_library }}
+
+      - name: Build Universal Binary for MacOS Jni
+        run: |
+          cargo build -p dsnp-graph-sdk-jni --profile release --target ${{ matrix.additional-rust-target }}
+          lipo -create -output artifacts/${{ matrix.java_library }} target/${{ matrix.additional-rust-target }}/release/${{ matrix.java_library }} target/release/${{ matrix.java_library }}
+        if: matrix.os == 'macos-latest'
+
+      - name: Build Universal Binary for MacOS Node
+        run: |
+          cargo build -p dsnp-graph-sdk-node --profile release --target ${{ matrix.additional-rust-target }}
+          lipo -create -output artifacts/${{ matrix.node_library }} target/${{ matrix.additional-rust-target }}/release/${{ matrix.node_library }} target/release/${{ matrix.node_library }}
+        if: matrix.os == 'macos-latest'
+
+      - name: Build with Gradle
+        working-directory: java
+        run: ./gradlew build
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts-${{github.run_id}}
+          path: |
+            artifacts/${{ matrix.java_library }}
+            artifacts/${{ matrix.node_library }}
+
+  publish-java:
+    name: Build and Publish JVM
+    runs-on: ubuntu-latest
+    needs: build-artifacts
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Java
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Build JNI package
+        run: make build-jni
+      - name: Build and Publish with Gradle
+        working-directory: java
+        run: |
+          # removing v from in front of tag to get version
+          NEW_VERSION=$(echo '${{ env.NEW_RELEASE_TAG }}' | cut -d 'v' -f 2)
+          echo "New version: $NEW_VERSION"
+          ./gradlew -PprojVersion="$NEW_VERSION" build
+      - name: Publish to GitHub Packages
+        working-directory: java
+        run: ./gradlew publish
+        if: env.TEST_RUN != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+
+  publish_npm_package:
+    name: Publish NPM Package
+    runs-on: ubuntu-latest
+    needs: build-artifacts
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install NPM Dependencies
+        working-directory: bridge/node
+        run: npm install
+
+      - name: Get current version
+        id: version
+        working-directory: bridge/node
+        run: echo ::set-output name=version::$(node -p "require('./package.json').version")
+
+      - name: Show versions
+        working-directory: bridge/node
+        run: |
+          echo "Package: v{{ steps.version.outputs.version }}"
+          echo " Actual: ${{ env.NEW_RELEASE_TAG }}"
+
+      - name: Use the new version
+        working-directory: bridge/node
+        run: |
+          npm version --new-version "${{ env.NEW_RELEASE_TAG }}"
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "New version: $NEW_VERSION"
+        env:
+          FULL_SHA: ${{ github.sha }}
+
+      - name: Build NPM Package
+        working-directory: bridge/node
+        run: npm run native:build-release && cp README.md dist/README.md
+
+      - name: Publish NPM Package
+        working-directory: bridge/node
+        if: env.TEST_RUN != 'true'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
+      - name: Dry run NPM Package
+        working-directory: bridge/node
+        if: env.TEST_RUN == 'true'
+        run: npm publish --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
+  generate-docs:
+    name: Generate graph sdk rust docs
+    runs-on: ubuntu-latest
+    needs: build-artifacts
+    permissions:
+      contents: read
+      packages: write
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal
+          target: wasm32-unknown-unknown
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Build Docs
+        run: |
+          RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps --all-features
+      - name: Fix file permissions
+        shell: sh
+        run: |
+          chmod -c -R +rX "target/doc" |
+          while read line; do
+              echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+      - name: Upload Docs
+        uses: actions/upload-pages-artifact@v1
+        if: env.TEST_RUN != 'true'
+        with:
+          path: ./target/doc
+      - name: Deploy Docs
+        uses: actions/deploy-pages@v2
+        if: env.TEST_RUN != 'true'
+        id: deployment
+
+  release:
+    needs: [publish-java, publish_npm_package, generate-docs]
+    runs-on: ubuntu-latest
+    name: Release generated artifacts
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Download Binaries
+        id: download-binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts-${{github.run_id}}
+          path: downloaded
+      - name: List Downloaded Binaries
+        run: |
+          download_dir=${{steps.download-binaries.outputs.download-path}}
+          echo "Download dir: $download_dir"
+          echo "Downloaded binaries: $(ls -l $download_dir)"
+          ls -R
+      - name: creating release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        with:
+          files: |
+            downloaded/*
+          prerelease: ${{ env.TEST_RUN }}
+          name: ${{env.NEW_RELEASE_TAG}}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
-rust 1.64
+rust 1.71.1
 make 4.3
 cmake 3.24.1
 protoc 3.12.4
 # clang 14.0.6 # only plugin I could find for clang and not some subset of clang did not work, it was located here https://github.com/srivathsanmurali/asdf-clang.git
-
+java corretto-17.0.2.8.1

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ build-node:
 	@echo "Build Neon Node Bridge for GraphSDK..."
 	@cd bridge/node && npm install && npm run native:build-release
 
+.PHONY: build-node-download
+build-node-download:
+	@echo "Build Bridge by downloading native binaries for GraphSDK..."
+	@cd bridge/node && npm install && npm run native:download
 
 .PHONY: dsnp-graph-sdk-jni
 	@cargo build -p dsnp-graph-sdk-jni --profile $(PROFILE)
@@ -105,6 +109,10 @@ test-ffi: build-ffi-tests
 test-node: build-node
 	@cd bridge/node && npx jest --verbose
 
+.PHONY: test-node-download
+test-node-download: build-node-download
+	@cd bridge/node && npx jest --verbose
+
 .PHONY: test-jni
 test-jni: build-jni
 	@( cd java ; ./gradlew test --rerun-tasks)
@@ -122,7 +130,12 @@ test-all: test test-ffi test-jni test-node
 build-jni:
 	@echo "Build JNI ..."
 	cargo build -p dsnp-graph-sdk-jni --profile $(PROFILE)
-	@./scripts/install_jni.sh
+	# using bash to support windows compatibility
+	bash ./scripts/install_jni.sh
+
+.PHONY: download-jni
+download-jni:
+	@( cd java ; ./gradlew downloadJniBinaries)
 
 .PHONY: install-protobuf-codegen
 install-protobuf-codegen:

--- a/bridge/node/downloadBinaries.js
+++ b/bridge/node/downloadBinaries.js
@@ -1,0 +1,43 @@
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const version = require("./package.json").customProperties.uploadedBinariesVersion
+
+const platform = os.platform();
+console.log(platform)
+
+let fileName;
+switch (platform) {
+    case 'darwin':
+        fileName = 'libdsnp_graph_sdk_node.dylib';
+        break;
+    case 'win32':
+        fileName = 'dsnp_graph_sdk_node.dll';
+        break;
+    case 'linux':
+        fileName = 'libdsnp_graph_sdk_node.so';
+        break;
+    default:
+        fileName = 'libdsnp_graph_sdk_node.so';
+}
+
+// URL of the file to download
+const fileUrl = 'https://github.com/LibertyDSNP/graph-sdk/releases/download/' + version + '/' + fileName;
+
+// Complete output file path
+const outputFile = path.join(__dirname, 'dsnp_graph_sdk_node.node');
+
+// Download the file using axios
+axios({
+    method: 'get',
+    url: fileUrl,
+    responseType: 'stream'
+})
+    .then(response => {
+        response.data.pipe(fs.createWriteStream(outputFile));
+        console.log('Download completed:', outputFile);
+    })
+    .catch(error => {
+        console.error('Error downloading file:', error.message);
+    });

--- a/bridge/node/package-lock.json
+++ b/bridge/node/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@dsnp/graph-sdk",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dsnp/graph-sdk",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.2",
         "@types/node": "^20.2.5",
         "@typescript-eslint/eslint-plugin": "^5.59.9",
         "@typescript-eslint/parser": "^5.59.9",
+        "axios": "^1.4.0",
         "cargo-cp-artifact": "^0.1",
         "eslint": "^8.42.0",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -1806,6 +1807,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -1816,6 +1823,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2186,6 +2204,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2426,6 +2456,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-newline": {
@@ -3133,6 +3172,26 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -3140,6 +3199,20 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -4732,6 +4805,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -5218,6 +5312,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/punycode": {
       "version": "2.3.0",
@@ -7585,11 +7685,28 @@
         "is-shared-array-buffer": "^1.0.2"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "babel-jest": {
       "version": "29.5.0",
@@ -7846,6 +7963,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8006,6 +8132,12 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -8547,6 +8679,12 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true
+    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -8554,6 +8692,17 @@
       "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "fs.realpath": {
@@ -9707,6 +9856,21 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -10056,6 +10220,12 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "punycode": {
       "version": "2.3.0",

--- a/bridge/node/package.json
+++ b/bridge/node/package.json
@@ -13,6 +13,7 @@
     "native:build": "tsc && cargo-cp-artifact -a cdylib dsnp_graph_sdk_node dsnp_graph_sdk_node.node -- cargo build --message-format=json-render-diagnostics",
     "native:build-debug": "npm run native:build --",
     "native:build-release": "npm run native:build -- --release && npm run cp:dsnp_graph_sdk_node.node",
+    "native:download": "tsc && node downloadBinaries.js && npm run cp:dsnp_graph_sdk_node.node",
     "test:cargo": "cargo test",
     "lint": "eslint js/ --ext .ts",
     "lint:fix": "eslint --fix js/ --ext .ts"
@@ -34,7 +35,8 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.5.0",
-    "ts-jest": "^29.1.0"
+    "ts-jest": "^29.1.0",
+    "axios": "^1.4.0"
   },
   "repository": {
     "type": "git",
@@ -51,5 +53,8 @@
   "bugs": {
     "url": "https://github.com/LibertyDSNP/graph-sdk/issues"
   },
-  "homepage": "https://github.com/LibertyDSNP/graph-sdk/bridge/node/README.md"
+  "homepage": "https://github.com/LibertyDSNP/graph-sdk/bridge/node/README.md",
+  "customProperties": {
+    "uploadedBinariesVersion": "v0.0.1-rc1"
+  }
 }

--- a/java/lib/build.gradle.kts
+++ b/java/lib/build.gradle.kts
@@ -1,3 +1,4 @@
+import de.undercouch.gradle.tasks.download.Download
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -7,11 +8,17 @@ plugins {
     id("maven-publish")
     id("java-library")
     id("signing")
+    id("de.undercouch.download") version "5.0.2"
 }
 
 group = "io.amplica.graphsdk"
-version = "0.0.2-SNAPSHOT"
+val uploadedBinariesVersion = "0.0.1-rc1"
 java.sourceCompatibility = JavaVersion.VERSION_17
+version = if (project.hasProperty("projVersion")) {
+    project.properties["projVersion"]!!
+} else {
+    "0.0.2-SNAPSHOT"
+}
 
 repositories {
 	maven {
@@ -40,6 +47,11 @@ java {
 	withSourcesJar()
 }
 
+tasks.register("printVersion") {
+    shouldRunAfter("build")
+    println("version = $version")
+}.get()
+
 tasks.withType<KotlinCompile> {
 	kotlinOptions {
 		freeCompilerArgs = listOf("-Xjsr305=strict")
@@ -54,6 +66,19 @@ tasks.withType<Test> {
         // showStandardStreams = true
 		events("passed", "skipped", "failed")
 	}
+}
+
+tasks.register("downloadJniBinaries", Download::class.java) {
+    enabled = true
+
+    println("Downloading Jni Binaries...")
+    val extraResources = arrayOf("dsnp_graph_sdk_jni.dll", "libdsnp_graph_sdk_jni.dylib", "libdsnp_graph_sdk_jni.so")
+
+    src(extraResources.map {
+        "https://github.com/LibertyDSNP/graph-sdk/releases/download/v$uploadedBinariesVersion/$it"
+    })
+    overwrite(true)
+    dest("src/main/resources")
 }
 
 // Configure publishing


### PR DESCRIPTION
# Goal
The goal of this PR is to facilitate releases for graph-sdk

Closes #102
Related to  #155 
Related to #154

# Changes
- publishing pre-built binaries as release assets which gradle and node bridges can download using `make download-jni` and `make build-node-download` commands. The idea is that we currently only need non linux targets for developing.
- Used universal binaries for macOS native binaries supporting `aarch64-apple-darwin` and `x86_64-apple-darwin`

# Discussions
- Tried using that https://github.com/dherman/sniff-bytes/blob/main/.github/workflows/publish.yml for publishing multi-target packages but the inner actions used are all blocked and we would need to whitelist all of them .


