### PR TITLE
Shared object creation for amd64 and aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,8 @@ test-all: test test-ffi test-jni test-node
 .PHONY: build-jni
 build-jni:
 	@echo "Build JNI ..."
-	cargo build -p dsnp-graph-sdk-jni --profile $(PROFILE)
+	cargo build -p dsnp-graph-sdk-jni --profile $(PROFILE) --target=x86_64-unknown-linux-gnu
+	cargo build -p dsnp-graph-sdk-jni --profile $(PROFILE) --target=aarch64-unknown-linux-gnu
 	# using bash to support windows compatibility
 	bash ./scripts/install_jni.sh
 

--- a/java/lib/src/main/java/io/amplica/graphsdk/Native.java
+++ b/java/lib/src/main/java/io/amplica/graphsdk/Native.java
@@ -11,10 +11,24 @@ public final class Native {
     private Native() {
     }
 
+    private static String obtainPlatform() {
+        String os = System.getProperty("os.name", "unknown");
+        String arch = System.getProperty("os.arch", "unknown");
+
+        if (os.contains("nux") && arch.contains("amd64")) {
+            return "x86_64-unknown-linux-gnu";
+        } else if (os.contains("nux") && arch.contains("aarch64")) {
+            return "aarch64-unknown-linux-gnu";
+        } else {
+            throw new RuntimeException(String.format("Not supported platform: os = %s; arch = %s", os, arch));
+        }
+    }
+
     private static void loadLibrary() {
         try {
+            String platform = obtainPlatform();
             String libraryName = System.mapLibraryName("dsnp_graph_sdk_jni");
-            try (InputStream in = Native.class.getResourceAsStream("/" + libraryName)) {
+            try (InputStream in = Native.class.getResourceAsStream("/" + platform + "/" + libraryName)) {
                 if (in != null) {
                     copyToTempFileAndLoad(in, libraryName);
                 } else {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "nightly-2023-06-01"
-components = [ "clippy", "rust-docs", "rustfmt","rustc-dev", "rustc"]
-targets = [ "wasm32-unknown-unknown" ]
+components = [ "clippy", "rust-docs", "rustfmt","rustc-dev", "rustc" ]
+targets = [ "wasm32-unknown-unknown", "aarch64-unknown-linux-gnu" ]
 profile = "minimal"

--- a/scripts/install_jni.sh
+++ b/scripts/install_jni.sh
@@ -1,16 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
 BACKEND_LIB_DIR=java/lib/src/main/resources
 JNI_NAME=dsnp_graph_sdk_jni
 
-install -d ${BACKEND_LIB_DIR}
 for possible_library_name in "lib${JNI_NAME}.dylib" "lib${JNI_NAME}.so" "${JNI_NAME}.dll"; do
-  possible_library_path="target/release/${possible_library_name}"
-  if [ -e "${possible_library_path}" ]; then
-    echo "Installing ${possible_library_name} to ${BACKEND_LIB_DIR}"
-    install "${possible_library_path}" "${BACKEND_LIB_DIR}"
-    break
-  fi
+
+  for possible_target in "x86_64-unknown-linux-gnu" "aarch64-unknown-linux-gnu"; do
+      possible_library_path="target/${possible_target}/release/${possible_library_name}"
+      if [ -e "${possible_library_path}" ]; then
+          DESTDIR="${BACKEND_LIB_DIR}/${possible_target}"
+          echo "Installing ${possible_library_name} to $DESTDIR"
+          install -d ${DESTDIR}
+          install "${possible_library_path}" ${DESTDIR}
+      fi
+  done
 done


### PR DESCRIPTION
# Goal
The goal of this PR is the release for aarch64 platform.

# Discussion
- adds aarch64 as release target for jni *.so file
- possible missing of other architectures: x86_64-apple-darwin, x86_64-pc-windows-gnu, aarch64-apple-darwin

# Checklist
- [ ] Tests added
