### PR TITLE
fix: when generating page_capacities.rs, do not format other source file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ clean:
 .PHONY: capacities
 capacities:
 	@echo "Generating graph page capacities..."
-	@cargo test --features=calculate-page-capacity calculate_page_capacities; cargo fmt
+	@cargo test --features=calculate-page-capacity calculate_page_capacities; rustfmt core/src/graph/page_capacities.rs
 
 .PHONY: all
 all: check test clippy deny format build doc


### PR DESCRIPTION
# Goal
The goal of this PR is to avoid re-formatting all source files when we only want to generate a new `page_capacities.rs` file.
