### PR TITLE
fix: remove unnecessary borrow/clone

### DIFF
--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -506,9 +506,8 @@ impl GraphState {
 					..
 				} => {
 					let ignore_existing_connections = match options {
-						Some(ActionOptions { ignore_existing_connections, .. }) => {
-							*ignore_existing_connections
-						},
+						Some(ActionOptions { ignore_existing_connections, .. }) =>
+							*ignore_existing_connections,
 						None => false,
 					};
 					if owner_graph.graph_has_connection(*schema_id, *dsnp_user_id, true) {
@@ -544,9 +543,8 @@ impl GraphState {
 					..
 				} => {
 					let ignore_missing_connections = match options {
-						Some(ActionOptions { ignore_missing_connections, .. }) => {
-							*ignore_missing_connections
-						},
+						Some(ActionOptions { ignore_missing_connections, .. }) =>
+							*ignore_missing_connections,
 						None => false,
 					};
 					if !owner_graph.graph_has_connection(*schema_id, *dsnp_user_id, true) {

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -443,7 +443,7 @@ impl GraphState {
 
 			if pages.is_empty() {
 				// case where only keys are imported
-				continue
+				continue;
 			}
 
 			let dsnp_config = user_graph
@@ -506,8 +506,9 @@ impl GraphState {
 					..
 				} => {
 					let ignore_existing_connections = match options {
-						Some(ActionOptions { ignore_existing_connections, .. }) =>
-							*ignore_existing_connections,
+						Some(ActionOptions { ignore_existing_connections, .. }) => {
+							*ignore_existing_connections
+						},
 						None => false,
 					};
 					if owner_graph.graph_has_connection(*schema_id, *dsnp_user_id, true) {
@@ -517,16 +518,16 @@ impl GraphState {
 								action.owner_dsnp_user_id(),
 								*dsnp_user_id
 							);
-							continue
+							continue;
 						}
 
 						return Err(DsnpGraphError::ConnectionAlreadyExists(
 							action.owner_dsnp_user_id(),
 							*dsnp_user_id,
-						))
+						));
 					}
 					owner_graph.update_tracker_mut().register_update(
-						&UpdateEvent::create_add(*dsnp_user_id, *schema_id),
+						UpdateEvent::create_add(*dsnp_user_id, *schema_id),
 						ignore_existing_connections,
 					)?;
 					if let Some(inner_keys) = dsnp_keys {
@@ -543,8 +544,9 @@ impl GraphState {
 					..
 				} => {
 					let ignore_missing_connections = match options {
-						Some(ActionOptions { ignore_missing_connections, .. }) =>
-							*ignore_missing_connections,
+						Some(ActionOptions { ignore_missing_connections, .. }) => {
+							*ignore_missing_connections
+						},
 						None => false,
 					};
 					if !owner_graph.graph_has_connection(*schema_id, *dsnp_user_id, true) {
@@ -554,16 +556,16 @@ impl GraphState {
 								action.owner_dsnp_user_id(),
 								*dsnp_user_id
 							);
-							continue
+							continue;
 						}
 
 						return Err(DsnpGraphError::ConnectionDoesNotExist(
 							action.owner_dsnp_user_id(),
 							*dsnp_user_id,
-						))
+						));
 					}
 					owner_graph.update_tracker_mut().register_update(
-						&UpdateEvent::create_remove(*dsnp_user_id, *schema_id),
+						UpdateEvent::create_remove(*dsnp_user_id, *schema_id),
 						ignore_missing_connections,
 					)?;
 				},
@@ -727,8 +729,7 @@ mod test {
 	}
 
 	#[test]
-	fn import_user_data_should_without_private_keys_should_add_prids_for_private_friendship_graph()
-	{
+	fn import_user_data_without_private_keys_should_add_prids_for_private_friendship_graph() {
 		// arrange
 		let env = Environment::Mainnet;
 		let schema_id = env

--- a/core/src/graph/updates.rs
+++ b/core/src/graph/updates.rs
@@ -130,14 +130,10 @@ impl UpdateTracker {
 			synced_updates.retain(|e| match e {
 				UpdateEvent::Add { dsnp_user_id, .. }
 					if existing_connections.contains(&dsnp_user_id) =>
-				{
-					false
-				},
+					false,
 				UpdateEvent::Remove { dsnp_user_id, .. }
 					if !existing_connections.contains(&dsnp_user_id) =>
-				{
-					false
-				},
+					false,
 				_ => true,
 			});
 			if synced_updates.len() != arr.len() {
@@ -178,12 +174,10 @@ impl UpdateEvent {
 	/// returns the complement of the event
 	pub fn get_complement(&self) -> Self {
 		match self {
-			Add { dsnp_user_id, schema_id } => {
-				Remove { dsnp_user_id: *dsnp_user_id, schema_id: *schema_id }
-			},
-			Remove { dsnp_user_id, schema_id } => {
-				Add { dsnp_user_id: *dsnp_user_id, schema_id: *schema_id }
-			},
+			Add { dsnp_user_id, schema_id } =>
+				Remove { dsnp_user_id: *dsnp_user_id, schema_id: *schema_id },
+			Remove { dsnp_user_id, schema_id } =>
+				Add { dsnp_user_id: *dsnp_user_id, schema_id: *schema_id },
 		}
 	}
 

--- a/core/src/graph/updates.rs
+++ b/core/src/graph/updates.rs
@@ -83,14 +83,14 @@ impl UpdateTracker {
 	#[log_result_err(Level::Info)]
 	pub fn register_updates(
 		&mut self,
-		mut events: Vec<UpdateEvent>,
+		events: Vec<UpdateEvent>,
 		ignore_existing: bool,
 	) -> DsnpGraphResult<()> {
 		if !ignore_existing && events.iter().any(|e| self.contains(e)) {
 			return Err(DsnpGraphError::DuplicateUpdateEvents);
 		}
 
-		for e in events.drain(..) {
+		for e in events.into_iter() {
 			self.register_update(e, ignore_existing)?;
 		}
 

--- a/core/src/graph/user.rs
+++ b/core/src/graph/user.rs
@@ -188,8 +188,8 @@ impl UserGraph {
 			let remove_update_exists =
 				include_pending && self.update_tracker.contains_complement(add_event);
 
-			return (graph_connection_exists && !remove_update_exists) ||
-				(!graph_connection_exists && add_update_exists)
+			return (graph_connection_exists && !remove_update_exists)
+				|| (!graph_connection_exists && add_update_exists);
 		}
 		false
 	}
@@ -239,7 +239,7 @@ impl UserGraph {
 	pub fn get_dsnp_config(&self, schema_id: SchemaId) -> Option<DsnpVersionConfig> {
 		let config = self.environment.get_config();
 		if let Some(dsnp_version) = config.get_dsnp_version_from_schema_id(schema_id) {
-			return Some(DsnpVersionConfig::new(dsnp_version))
+			return Some(DsnpVersionConfig::new(dsnp_version));
 		}
 		None
 	}
@@ -370,7 +370,7 @@ mod test {
 		let connection_dsnp = 1000000;
 		user_graph
 			.update_tracker
-			.register_update(&UpdateEvent::Add { dsnp_user_id: connection_dsnp, schema_id }, false)
+			.register_update(UpdateEvent::Add { dsnp_user_id: connection_dsnp, schema_id }, false)
 			.unwrap();
 		let key = StackKeyPair::gen();
 		user_graph

--- a/core/src/graph/user.rs
+++ b/core/src/graph/user.rs
@@ -188,8 +188,8 @@ impl UserGraph {
 			let remove_update_exists =
 				include_pending && self.update_tracker.contains_complement(add_event);
 
-			return (graph_connection_exists && !remove_update_exists)
-				|| (!graph_connection_exists && add_update_exists);
+			return (graph_connection_exists && !remove_update_exists) ||
+				(!graph_connection_exists && add_update_exists);
 		}
 		false
 	}


### PR DESCRIPTION
# Goal
The goal of this PR is to remove some unnecessary borrowing + cloning when registering Graph update events. This should reduce some transient short-term memory usage.
