### PR TITLE
Fixed existing bug on transaction hashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
  "lazy_static",
  "log",
  "log-result-proc-macro",
+ "memory-stats",
  "miniz_oxide",
  "ntest",
  "pretty_assertions",
@@ -807,6 +808,16 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "memory-stats"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f79cf9964c5c9545493acda1263f1912f8d2c56c8a2ffee2606cb960acaacc"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "miniz_oxide"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,6 +38,7 @@ ntest = "0.9.0"
 log = "0.4.21"
 env_logger = "^0.11.2"
 ctor = "^0.2.7"
+memory-stats = "1.1.0"
 
 [features]
 wasm = ["wasm-bindgen"]

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -728,7 +728,7 @@ mod test {
 	}
 
 	#[test]
-	#[timeout(180000)]
+	#[timeout(3000)]
 	fn add_large_number_of_follows_to_private_follow_graph_should_succeed() {
 		// arrange
 		let env = Environment::Mainnet;
@@ -746,11 +746,9 @@ mod test {
 			key_type: GraphKeyType::X25519,
 		};
 		let dsnp_user_id = 7002;
-		// let connections = vec![(2, 0), (3, 0), (4, 0), (5, 0)];
 		let input = ImportBundleBuilder::new(env, dsnp_user_id, schema_id)
 			.with_key_pairs(&vec![keypair])
 			.with_encryption_key(resolved_key)
-			// .with_page(1, &connections, &vec![], 100)
 			.build();
 
 		// act
@@ -759,7 +757,6 @@ mod test {
 		// assert
 		assert!(res.is_ok());
 
-		println!("Creating action vector");
 		let actions: Vec<Action> = (1u64..7000u64)
 			.map(|id| Action::Connect {
 				owner_dsnp_user_id: dsnp_user_id,
@@ -767,7 +764,6 @@ mod test {
 				dsnp_keys: None,
 			})
 			.collect();
-		println!("Finished creating action vector");
 
 		let res = state.apply_actions(
 			&actions,

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -506,9 +506,8 @@ impl GraphState {
 					..
 				} => {
 					let ignore_existing_connections = match options {
-						Some(ActionOptions { ignore_existing_connections, .. }) => {
-							*ignore_existing_connections
-						},
+						Some(ActionOptions { ignore_existing_connections, .. }) =>
+							*ignore_existing_connections,
 						None => false,
 					};
 					if owner_graph.graph_has_connection(*schema_id, *dsnp_user_id, true) {
@@ -544,9 +543,8 @@ impl GraphState {
 					..
 				} => {
 					let ignore_missing_connections = match options {
-						Some(ActionOptions { ignore_missing_connections, .. }) => {
-							*ignore_missing_connections
-						},
+						Some(ActionOptions { ignore_missing_connections, .. }) =>
+							*ignore_missing_connections,
 						None => false,
 					};
 					if !owner_graph.graph_has_connection(*schema_id, *dsnp_user_id, true) {

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -589,6 +589,7 @@ mod test {
 		dsnp::{dsnp_configs::KeyPairType, dsnp_types::DsnpPrid},
 		util::builders::{ImportBundleBuilder, KeyDataBuilder},
 	};
+	use memory_stats::memory_stats;
 	use ntest::*;
 
 	#[test]
@@ -752,7 +753,13 @@ mod test {
 			.build();
 
 		// act
+		let mem_usage = memory_stats().unwrap();
+		println!("before data import physical mem: {}", mem_usage.physical_mem);
+
 		let res = state.import_users_data(&vec![input]);
+
+		let mem_usage = memory_stats().unwrap();
+		println!("after data import physical mem: {}", mem_usage.physical_mem);
 
 		// assert
 		assert!(res.is_ok());
@@ -764,6 +771,8 @@ mod test {
 				dsnp_keys: None,
 			})
 			.collect();
+		let mem_usage = memory_stats().unwrap();
+		println!("before action import physical mem: {}", mem_usage.physical_mem);
 
 		let res = state.apply_actions(
 			&actions,
@@ -772,6 +781,9 @@ mod test {
 				ignore_missing_connections: false,
 			}),
 		);
+
+		let mem_usage = memory_stats().unwrap();
+		println!("after action import physical mem: {}", mem_usage.physical_mem);
 
 		// assert
 		assert!(res.is_ok());

--- a/core/src/util/transactional_hashmap.rs
+++ b/core/src/util/transactional_hashmap.rs
@@ -12,19 +12,13 @@ pub trait Transactional {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-enum Reversible<K, V> {
-	Add { key: K, prev: Option<V> },
-	Remove { key: K, prev: V },
-}
-
-#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct TransactionalHashMap<K, V>
 where
 	K: Eq + Hash + Clone,
 	V: Clone,
 {
 	inner: HashMap<K, V>,
-	rollback_operations: Vec<Reversible<K, V>>,
+	original_items: HashMap<K, Option<V>>,
 }
 
 impl<K, V> TransactionalHashMap<K, V>
@@ -33,12 +27,15 @@ where
 	V: Clone,
 {
 	pub fn new() -> Self {
-		Self { inner: HashMap::new(), rollback_operations: vec![] }
+		Self { inner: HashMap::new(), original_items: HashMap::new() }
 	}
 
 	#[inline]
 	pub fn with_capacity(capacity: usize) -> Self {
-		Self { inner: HashMap::with_capacity(capacity), rollback_operations: vec![] }
+		Self {
+			inner: HashMap::with_capacity(capacity),
+			original_items: HashMap::with_capacity(capacity),
+		}
 	}
 
 	pub fn inner(&self) -> &HashMap<K, V> {
@@ -49,12 +46,16 @@ where
 	pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
 		match self.inner.entry(key.clone()) {
 			Entry::Vacant(v) => {
-				self.rollback_operations.push(Reversible::Add { prev: None, key });
+				if !self.original_items.contains_key(&key) {
+					self.original_items.insert(key, None);
+				}
 				Entry::Vacant(v)
 			},
 			Entry::Occupied(o) => {
-				self.rollback_operations
-					.push(Reversible::Add { prev: Some(o.get().clone()), key });
+				if !self.original_items.contains_key(&key) {
+					// extra clone of the value since we have to keep the original
+					self.original_items.insert(key, Some(o.get().clone()));
+				}
 				Entry::Occupied(o)
 			},
 		}
@@ -63,15 +64,19 @@ where
 	#[inline]
 	pub fn insert(&mut self, k: K, v: V) -> Option<V> {
 		let prev = self.inner.remove(&k);
-		self.rollback_operations.push(Reversible::Add { prev, key: k.clone() });
+		if !self.original_items.contains_key(&k) {
+			self.original_items.insert(k.clone(), prev);
+		}
 		self.inner.insert(k, v)
 	}
 
 	#[inline]
 	pub fn remove(&mut self, k: &K) -> Option<V> {
 		if let Some(v) = self.inner.remove(&k) {
-			self.rollback_operations
-				.push(Reversible::Remove { prev: v.clone(), key: k.clone() });
+			if !self.original_items.contains_key(&k) {
+				// extra clone of the value since we have to keep the original
+				self.original_items.insert(k.clone(), Some(v.clone()));
+			}
 			return Some(v)
 		}
 		None
@@ -79,12 +84,11 @@ where
 
 	#[inline]
 	pub fn clear(&mut self) {
-		for (key, value) in self.inner.iter() {
-			self.rollback_operations
-				.push(Reversible::Remove { key: key.clone(), prev: value.clone() });
+		for (key, value) in self.inner.drain() {
+			if !self.original_items.contains_key(&key) {
+				self.original_items.insert(key.clone(), Some(value));
+			}
 		}
-
-		self.inner.clear()
 	}
 
 	#[inline]
@@ -142,18 +146,14 @@ where
 	V: Clone,
 {
 	fn commit(&mut self) {
-		self.rollback_operations = vec![];
+		self.original_items = HashMap::new();
 	}
 
 	fn rollback(&mut self) {
-		while !self.rollback_operations.is_empty() {
-			let op = self.rollback_operations.pop().unwrap();
-			match op {
-				Reversible::Add { prev, key } => match prev {
-					Some(old) => self.inner.insert(key, old),
-					None => self.inner.remove(&key),
-				},
-				Reversible::Remove { prev, key } => self.inner.insert(key, prev),
+		for (key, v) in self.original_items.drain() {
+			match v {
+				Some(old) => self.inner.insert(key, old),
+				None => self.inner.remove(&key),
 			};
 		}
 	}
@@ -220,7 +220,7 @@ mod tests {
 		let inner_sorted: BTreeMap<_, _> = transactional.inner.clone().into_iter().collect();
 		assert_eq!(inner_sorted, expected);
 
-		assert_eq!(transactional.rollback_operations.len(), 0);
+		assert_eq!(transactional.original_items.len(), 0);
 	}
 
 	#[test]
@@ -239,5 +239,41 @@ mod tests {
 		transactional.rollback();
 		let inner_sorted: BTreeMap<_, _> = transactional.inner.clone().into_iter().collect();
 		assert_eq!(inner_sorted, BTreeMap::from([(5, 200)]));
+	}
+
+	#[test]
+	fn transactional_hashmap_vec() {
+		let mut transactional: TransactionalHashMap<u32, Vec<u32>> = TransactionalHashMap::new();
+		for i in 1..5 {
+			transactional.entry(1).or_default().push(i);
+		}
+		for i in 10..15 {
+			transactional.entry(2).or_default().push(i);
+		}
+
+		assert_eq!(transactional.original_items.len(), 2);
+
+		let inner_sorted: BTreeMap<_, _> = transactional.inner.clone().into_iter().collect();
+		assert_eq!(
+			inner_sorted,
+			BTreeMap::from([(1, vec![1, 2, 3, 4]), (2, vec![10, 11, 12, 13, 14])])
+		);
+
+		transactional.commit();
+
+		for i in (0..3).rev() {
+			transactional.entry(1).or_default().remove(i);
+		}
+
+		let inner_sorted: BTreeMap<_, _> = transactional.inner.clone().into_iter().collect();
+		assert_eq!(inner_sorted, BTreeMap::from([(1, vec![4]), (2, vec![10, 11, 12, 13, 14])]));
+
+		transactional.rollback();
+		let inner_sorted: BTreeMap<_, _> = transactional.inner.clone().into_iter().collect();
+		assert_eq!(
+			inner_sorted,
+			BTreeMap::from([(1, vec![1, 2, 3, 4]), (2, vec![10, 11, 12, 13, 14])])
+		);
+		assert_eq!(transactional.original_items.len(), 0);
 	}
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to address the bug in `transactional-hashmap` that instead of only keeping track of original state it was keeping track of all the intermediate states which was allocating excessive memory and causing Out of memory errors.

Closes #190 

# Discussion
- Fixed the implementation of transaction-hashmap to only keep track of the persisted state

# Checklist
- [x] Tests added
