### PR TITLE
bugfix: fixed next page id calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "dsnp-graph-config"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "dsnp-graph-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "dsnp-graph-sdk-common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "dsnp-graph-config",
  "dsnp-graph-core",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "dsnp-graph-sdk-ffi"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "dsnp-graph-config",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "dsnp-graph-sdk-jni"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if",
  "dsnp-graph-config",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "dsnp-graph-sdk-node"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "dsnp-graph-config",
  "dsnp-graph-core",

--- a/bridge/common/Cargo.toml
+++ b/bridge/common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "dsnp-graph-sdk-common"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
 
 [dependencies]
-dsnp-graph-core = { version = "1.1.0", path = "../../core" }
-dsnp-graph-config = { version = "1.1.0", path = "../../config" }
+dsnp-graph-core = { version = "1.1.1", path = "../../core" }
+dsnp-graph-config = { version = "1.1.1", path = "../../config" }
 libc = "0.2.153"
 protobuf = { version = "3.4.0", features = ["with-bytes"] }

--- a/bridge/ffi/Cargo.toml
+++ b/bridge/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsnp-graph-sdk-ffi"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
@@ -10,8 +10,8 @@ name = "dsnp_graph_sdk_ffi"
 crate-type = ["staticlib"]
 
 [dependencies]
-dsnp-graph-core = { version = "1.1.0", path = "../../core" }
-dsnp-graph-config = { version = "1.1.0", path = "../../config" }
+dsnp-graph-core = { version = "1.1.1", path = "../../core" }
+dsnp-graph-config = { version = "1.1.1", path = "../../config" }
 libc = "0.2.153"
 lazy_static = "1.4.0"
 anyhow = "1.0.80"

--- a/bridge/jni/Cargo.toml
+++ b/bridge/jni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsnp-graph-sdk-jni"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
@@ -10,9 +10,9 @@ name = "dsnp_graph_sdk_jni"
 crate-type = ["cdylib"]
 
 [dependencies]
-dsnp-graph-core = { version = "1.1.0", path = "../../core" }
-dsnp-graph-config = { version = "1.1.0", path = "../../config" }
-dsnp-graph-sdk-common = { version = "1.1.0", path = "../common" }
+dsnp-graph-core = { version = "1.1.1", path = "../../core" }
+dsnp-graph-config = { version = "1.1.1", path = "../../config" }
+dsnp-graph-sdk-common = { version = "1.1.1", path = "../common" }
 jni = "0.21.1"
 cfg-if = "1.0.0"
 log = { version = "^0.4.21", features = ["std", "max_level_debug", "release_max_level_debug"] }

--- a/bridge/node/Cargo.toml
+++ b/bridge/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsnp-graph-sdk-node"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
@@ -11,8 +11,8 @@ name = "dsnp_graph_sdk_node"
 crate-type = ["cdylib"]
 
 [dependencies]
-dsnp-graph-core = { version = "1.1.0", path = "../../core" }
-dsnp-graph-config = { version = "1.1.0", path = "../../config" }
+dsnp-graph-core = { version = "1.1.1", path = "../../core" }
+dsnp-graph-config = { version = "1.1.1", path = "../../config" }
 neon = { version = "1.0.0", default-features = false, features = ["napi-6"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"

--- a/bridge/node/package-lock.json
+++ b/bridge/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dsnp/graph-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dsnp/graph-sdk",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/bridge/node/package.json
+++ b/bridge/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsnp/graph-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Amplica Labs",
   "license": "Apache-2.0",
   "description": "dsnp-graph-sdk-node",
@@ -55,6 +55,6 @@
   },
   "homepage": "https://github.com/LibertyDSNP/graph-sdk/bridge/node/README.md",
   "customProperties": {
-    "uploadedBinariesVersion": "v1.1.0"
+    "uploadedBinariesVersion": "v1.1.1"
   }
 }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://spec.dsnp.org"
 license = "Apache-2.0"
 publish = false
 repository = "https://github.com/libertyDSNP/graph-sdk/"
-version = "1.1.0"
+version = "1.1.1"
 
 [lib]
 name = "dsnp_graph_config"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://spec.dsnp.org"
 license = "Apache-2.0"
 publish = false
 repository = "https://github.com/libertyDSNP/graph-sdk/"
-version = "1.1.0"
+version = "1.1.1"
 
 [lib]
 name = "dsnp_graph_core"
@@ -16,7 +16,7 @@ doctest = false
 anyhow = "1.0.69"
 apache-avro = { version = "0.16.0", features = ["snappy"] }
 dryoc = "0.5.3"
-dsnp-graph-config = { version = "1.1.0", path = "../config" }
+dsnp-graph-config = { version = "1.1.1", path = "../config" }
 lazy_static = "1.4.0"
 log = { version = "^0.4.21", features = ["std", "max_level_debug", "release_max_level_debug"] }
 log-result-proc-macro = { path = "../log-result-proc-macro" }

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -733,7 +733,7 @@ mod test {
 	}
 
 	#[test]
-	#[timeout(30000)]
+	#[timeout(100000)]
 	fn add_large_number_of_follows_to_private_follow_graph_should_succeed() {
 		// arrange
 		let env = Environment::Mainnet;
@@ -799,7 +799,7 @@ mod test {
 
 		let export = state.export_updates();
 
-		assert!(res.is_ok());
+		assert!(export.is_ok());
 		println!("after export physical mem: {}", mem_usage.physical_mem);
 
 		let updates = export.unwrap();

--- a/core/src/api/api.rs
+++ b/core/src/api/api.rs
@@ -733,7 +733,7 @@ mod test {
 	}
 
 	#[test]
-	#[timeout(3000)]
+	#[timeout(30000)]
 	fn add_large_number_of_follows_to_private_follow_graph_should_succeed() {
 		// arrange
 		let env = Environment::Mainnet;
@@ -751,9 +751,9 @@ mod test {
 			key_type: GraphKeyType::X25519,
 		};
 		let dsnp_user_id = 7002;
-		let input = ImportBundleBuilder::new(env, dsnp_user_id, schema_id)
-			.with_key_pairs(&vec![keypair])
-			.with_encryption_key(resolved_key)
+		let input = ImportBundleBuilder::new(env.clone(), dsnp_user_id, schema_id)
+			.with_key_pairs(&vec![keypair.clone()])
+			.with_encryption_key(resolved_key.clone())
 			.build();
 
 		// act
@@ -792,6 +792,34 @@ mod test {
 
 		// assert
 		assert!(res.is_ok());
+
+		let connections =
+			state.get_connections_for_user_graph(&dsnp_user_id, &schema_id, true).unwrap();
+		let before_export_set: HashSet<_> = connections.iter().map(|e| e.user_id).collect();
+
+		let export = state.export_updates();
+
+		assert!(res.is_ok());
+		println!("after export physical mem: {}", mem_usage.physical_mem);
+
+		let updates = export.unwrap();
+
+		let mut updated_state = GraphState::new(env.clone());
+		let updated_input = ImportBundleBuilder::new(env.clone(), dsnp_user_id, schema_id)
+			.with_key_pairs(&vec![keypair])
+			.with_encryption_key(resolved_key.clone())
+			.build();
+
+		let new_import = ImportBundleBuilder::build_from(&updated_input, &updates);
+		let res = updated_state.import_users_data(&vec![new_import]);
+
+		assert!(res.is_ok());
+
+		let connections = updated_state
+			.get_connections_for_user_graph(&dsnp_user_id, &schema_id, false)
+			.unwrap();
+		let after_reimport_set: HashSet<_> = connections.iter().map(|e| e.user_id).collect();
+		assert_eq!(before_export_set, after_reimport_set);
 	}
 
 	#[test]

--- a/core/src/tests/helpers.rs
+++ b/core/src/tests/helpers.rs
@@ -20,7 +20,10 @@ use base64::{engine::general_purpose, Engine as _};
 use ctor::ctor;
 use dryoc::keypair::StackKeyPair;
 use dsnp_graph_config::{DsnpVersion, Environment, GraphKeyType};
-use std::sync::{Arc, RwLock};
+use std::{
+	collections::BTreeMap,
+	sync::{Arc, RwLock},
+};
 
 #[ctor]
 fn test_harness_init() {
@@ -134,7 +137,7 @@ pub fn create_aggressively_full_page(
 	shared_state: &Arc<RwLock<SharedStateManager>>,
 ) -> PageId {
 	let connection_type = graph.get_connection_type();
-	let page_id = graph.get_next_available_page_id().unwrap();
+	let page_id = graph.get_next_available_page_id(&BTreeMap::default()).unwrap();
 	let mut page = GraphPage::new(connection_type.privacy_type(), page_id);
 	let mut connection_id = start_conn_id;
 	let encryption_key = graph


### PR DESCRIPTION
# Goal
The goal of this PR is fix the bug which exports only the last page instead of all of them when more than 1 page is created via adding connections.

Closes #194 

# Checklist
- [X] updated versions
- [X] Tests added
